### PR TITLE
feat: handle x-upstream-extra-data aws credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,43 @@ Copy `.env.example` to `.env` and customize it for your environment:
 |WEB_CONCURRENCY|1|Number of workers for the server|
 |TEST_SERVER_URL|http://0.0.0.0:5001|Server URL used in the integration tests|
 
+## Load balancing
+
+If you use DIAL Core load balancing mechanism, you can provide `extraData` upstream setting with different aws account credentials/regions to use different model deployments:
+
+```json
+{
+  "upstreams": [
+    {
+      "extraData": {
+        "region": "eu-west-1",
+        "aws_access_key_id": "key_id_1",
+        "aws_secret_access_key": "access_key_1"
+      }
+    },
+    {
+      "extraData": {
+        "region": "eu-west-1",
+        "aws_access_key_id": "key_id_2",
+        "aws_secret_access_key": "access_key_2"
+      }
+    },
+    {
+      "extraData": {
+        "region": "eu-west-1",
+        "aws_assume_role_arn": "arn:aws:iam::123456789012:role/BedrockAccessAdapterRoleName"
+      }
+    }
+  ]
+}
+```
+
+Supported `extraData` fields:
+- `region`
+- `aws_access_key_id`
+- `aws_secret_access_key`
+- `aws_assume_role_arn`
+
 ### Docker
 
 Run the server in Docker:

--- a/aidial_adapter_bedrock/app.py
+++ b/aidial_adapter_bedrock/app.py
@@ -40,11 +40,11 @@ async def models():
 for deployment in ChatCompletionDeployment:
     app.add_chat_completion(
         deployment.deployment_id,
-        BedrockChatCompletion(region=AWS_DEFAULT_REGION),
+        BedrockChatCompletion(),
     )
 
 for deployment in EmbeddingsDeployment:
     app.add_embeddings(
         deployment.deployment_id,
-        BedrockEmbeddings(region=AWS_DEFAULT_REGION),
+        BedrockEmbeddings(),
     )

--- a/aidial_adapter_bedrock/aws_client_config.py
+++ b/aidial_adapter_bedrock/aws_client_config.py
@@ -48,7 +48,7 @@ class AWSClientConfig(BaseModel):
 
 
 class AWSClientConfigFactory:
-    RAW_UPSTREAM_CONFIG_HEADER_NAME = "x-upstream-extra-data"
+    UPSTREAM_CONFIG_HEADER_NAME = "x-upstream-extra-data"
     BEDROCK_ACCESS_SESSION_NAME = "BedrockAccessSession"
 
     def __init__(self, request):
@@ -67,7 +67,7 @@ class AWSClientConfigFactory:
 
     def _get_upstream_config_from_request(self, request: Request) -> dict:
         raw_upstream_config = request.headers.get(
-            self.RAW_UPSTREAM_CONFIG_HEADER_NAME
+            self.UPSTREAM_CONFIG_HEADER_NAME
         )
         return json.loads(raw_upstream_config) if raw_upstream_config else {}
 
@@ -91,12 +91,10 @@ class AWSClientConfigFactory:
             RoleSessionName=self.BEDROCK_ACCESS_SESSION_NAME,
         )
 
+        assumed_role_credentials = assumed_role_object["Credentials"]
+
         return AWSClientCredentials(
-            aws_access_key_id=assumed_role_object["Credentials"]["AccessKeyId"],
-            aws_secret_access_key=assumed_role_object["Credentials"][
-                "SecretAccessKey"
-            ],
-            aws_session_token=assumed_role_object["Credentials"][
-                "SessionToken"
-            ],
+            aws_access_key_id=assumed_role_credentials["AccessKeyId"],
+            aws_secret_access_key=assumed_role_credentials["SecretAccessKey"],
+            aws_session_token=assumed_role_credentials["SessionToken"],
         )

--- a/aidial_adapter_bedrock/aws_client_config.py
+++ b/aidial_adapter_bedrock/aws_client_config.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from aidial_adapter_bedrock.utils.concurrency import make_async
 from aidial_adapter_bedrock.utils.env import get_aws_default_region
+from aidial_adapter_bedrock.utils.json import remove_nones
 
 
 class AWSClientCredentials(BaseModel):
@@ -28,22 +29,16 @@ class AWSClientConfig(BaseModel):
 
     def get_anthropic_bedrock_client_kwargs(self) -> dict:
         client_kwargs = {"aws_region": self.region}
+
         if self.credentials:
-            if self.credentials.aws_access_key_id:
-                client_kwargs.update(
-                    {"aws_access_key": self.credentials.aws_access_key_id}
-                )
-
-            if self.credentials.aws_secret_access_key:
-                client_kwargs.update(
-                    {"aws_secret_key": self.credentials.aws_secret_access_key}
-                )
-
-            if self.credentials.aws_session_token:
-                client_kwargs.update(
-                    {"aws_session_token": self.credentials.aws_session_token}
-                )
-
+            credentials = remove_nones(
+                {
+                    "aws_access_key": self.credentials.aws_access_key_id,
+                    "aws_secret_key": self.credentials.aws_secret_access_key,
+                    "aws_session_token": self.credentials.aws_session_token,
+                }
+            )
+            client_kwargs.update(credentials)
         return client_kwargs
 
 

--- a/aidial_adapter_bedrock/aws_client_config.py
+++ b/aidial_adapter_bedrock/aws_client_config.py
@@ -1,0 +1,102 @@
+import json
+
+import boto3
+from aidial_sdk.embeddings import Request
+from pydantic import BaseModel
+
+from aidial_adapter_bedrock.utils.concurrency import make_async
+from aidial_adapter_bedrock.utils.env import get_aws_default_region
+
+
+class AWSClientCredentials(BaseModel):
+    aws_access_key_id: str
+    aws_secret_access_key: str
+    aws_session_token: str | None = None
+
+
+class AWSClientConfig(BaseModel):
+    region: str
+    credentials: AWSClientCredentials | None = None
+
+    def get_boto_client_kwargs(self) -> dict:
+        client_kwargs = {"region_name": self.region}
+
+        if self.credentials:
+            client_kwargs.update(self.credentials.dict(exclude_none=True))
+
+        return client_kwargs
+
+    def get_anthropic_bedrock_client_kwargs(self) -> dict:
+        client_kwargs = {"aws_region": self.region}
+        if self.credentials:
+            if self.credentials.aws_access_key_id:
+                client_kwargs.update(
+                    {"aws_access_key": self.credentials.aws_access_key_id}
+                )
+
+            if self.credentials.aws_secret_access_key:
+                client_kwargs.update(
+                    {"aws_secret_key": self.credentials.aws_secret_access_key}
+                )
+
+            if self.credentials.aws_session_token:
+                client_kwargs.update(
+                    {"aws_session_token": self.credentials.aws_session_token}
+                )
+
+        return client_kwargs
+
+
+class AWSClientConfigFactory:
+    RAW_UPSTREAM_CONFIG_HEADER_NAME = "x-upstream-endpoint"
+    BEDROCK_ACCESS_SESSION_NAME = "BedrockAccessSession"
+
+    def __init__(self, request):
+        upstream_config = self._get_upstream_config_from_request(request)
+
+        self._region = upstream_config.get("region", get_aws_default_region())
+        self._access_key_id = upstream_config.get("aws_access_key_id")
+        self._secret_access_key = upstream_config.get("aws_secret_access_key")
+        self._assumed_role_arn = upstream_config.get("aws_assume_role_arn")
+
+    async def get_client_config(self) -> AWSClientConfig:
+        return AWSClientConfig(
+            region=self._region,
+            credentials=await self._get_client_credentials(),
+        )
+
+    def _get_upstream_config_from_request(self, request: Request) -> dict:
+        raw_upstream_config = request.headers.get(
+            self.RAW_UPSTREAM_CONFIG_HEADER_NAME
+        )
+        return json.loads(raw_upstream_config) if raw_upstream_config else {}
+
+    async def _get_client_credentials(self) -> AWSClientCredentials | None:
+        if self._access_key_id and self._secret_access_key:
+            return AWSClientCredentials(
+                aws_access_key_id=self._access_key_id,
+                aws_secret_access_key=self._secret_access_key,
+            )
+
+        if self._assumed_role_arn:
+            return await self._get_assumed_role_tmp_credentials()
+
+    async def _get_assumed_role_tmp_credentials(self) -> AWSClientCredentials:
+        sts_client = await make_async(
+            lambda: boto3.Session().client("sts", region_name=self._region)
+        )
+
+        assumed_role_object = sts_client.assume_role(
+            RoleArn=self._assumed_role_arn,
+            RoleSessionName=self.BEDROCK_ACCESS_SESSION_NAME,
+        )
+
+        return AWSClientCredentials(
+            aws_access_key_id=assumed_role_object["Credentials"]["AccessKeyId"],
+            aws_secret_access_key=assumed_role_object["Credentials"][
+                "SecretAccessKey"
+            ],
+            aws_session_token=assumed_role_object["Credentials"][
+                "SessionToken"
+            ],
+        )

--- a/aidial_adapter_bedrock/aws_client_config.py
+++ b/aidial_adapter_bedrock/aws_client_config.py
@@ -48,7 +48,7 @@ class AWSClientConfig(BaseModel):
 
 
 class AWSClientConfigFactory:
-    RAW_UPSTREAM_CONFIG_HEADER_NAME = "x-upstream-endpoint"
+    RAW_UPSTREAM_CONFIG_HEADER_NAME = "x-upstream-extra-data"
     BEDROCK_ACCESS_SESSION_NAME = "BedrockAccessSession"
 
     def __init__(self, request):

--- a/aidial_adapter_bedrock/bedrock.py
+++ b/aidial_adapter_bedrock/bedrock.py
@@ -8,6 +8,7 @@ from botocore.eventstream import EventStream
 from botocore.response import StreamingBody
 from pydantic import BaseModel, Field
 
+from aidial_adapter_bedrock.aws_client_config import AWSClientConfig
 from aidial_adapter_bedrock.dial_api.token_usage import TokenUsage
 from aidial_adapter_bedrock.utils.concurrency import (
     make_async,
@@ -27,9 +28,11 @@ class Bedrock:
         self.client = client
 
     @classmethod
-    async def acreate(cls, region: str) -> "Bedrock":
+    async def acreate(cls, aws_client_config: AWSClientConfig) -> "Bedrock":
+        client_kwargs = aws_client_config.get_boto_client_kwargs()
+        client_kwargs["service_name"] = "bedrock-runtime"
         client = await make_async(
-            lambda: boto3.Session().client("bedrock-runtime", region)
+            lambda: boto3.Session().client(**client_kwargs)
         )
         return cls(client)
 

--- a/aidial_adapter_bedrock/chat_completion.py
+++ b/aidial_adapter_bedrock/chat_completion.py
@@ -23,6 +23,7 @@ from aidial_sdk.deployment.truncate_prompt import (
 from aidial_sdk.exceptions import ResourceNotFoundError
 from typing_extensions import override
 
+from aidial_adapter_bedrock.aws_client_config import AWSClientConfigFactory
 from aidial_adapter_bedrock.deployments import ChatCompletionDeployment
 from aidial_adapter_bedrock.dial_api.request import ModelParameters
 from aidial_adapter_bedrock.dial_api.token_usage import TokenUsage
@@ -39,21 +40,21 @@ from aidial_adapter_bedrock.utils.not_implemented import is_implemented
 
 
 class BedrockChatCompletion(ChatCompletion):
-    region: str
-
-    def __init__(self, region: str):
-        self.region = region
-
     async def _get_model(
         self, request: FromRequestDeploymentMixin
     ) -> ChatCompletionAdapter:
         deployment = ChatCompletionDeployment.from_deployment_id(
             request.deployment_id
         )
+
+        aws_client_config = await AWSClientConfigFactory(
+            request=request,
+        ).get_client_config()
+
         return await get_bedrock_adapter(
-            region=self.region,
             deployment=deployment,
             api_key=request.api_key,
+            aws_client_config=aws_client_config,
         )
 
     @dial_exception_decorator

--- a/aidial_adapter_bedrock/embeddings.py
+++ b/aidial_adapter_bedrock/embeddings.py
@@ -1,21 +1,22 @@
 from aidial_sdk.embeddings import Embeddings, Request, Response
 
+from aidial_adapter_bedrock.aws_client_config import AWSClientConfigFactory
 from aidial_adapter_bedrock.deployments import EmbeddingsDeployment
 from aidial_adapter_bedrock.llm.model.adapter import get_embeddings_model
 from aidial_adapter_bedrock.server.exceptions import dial_exception_decorator
 
 
 class BedrockEmbeddings(Embeddings):
-    def __init__(self, region: str):
-        self.region = region
-
     @dial_exception_decorator
     async def embeddings(self, request: Request) -> Response:
 
+        aws_client_config = await AWSClientConfigFactory(
+            request=request
+        ).get_client_config()
         model = await get_embeddings_model(
             deployment=EmbeddingsDeployment(request.deployment_id),
-            region=self.region,
             api_key=request.api_key,
+            aws_client_config=aws_client_config,
         )
 
         return await model.embeddings(request)

--- a/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
@@ -22,6 +22,7 @@ from anthropic.types import (
     ToolUseBlock,
 )
 
+from aidial_adapter_bedrock.aws_client_config import AWSClientConfig
 from aidial_adapter_bedrock.dial_api.request import ModelParameters
 from aidial_adapter_bedrock.dial_api.storage import (
     FileStorage,
@@ -220,10 +221,13 @@ class Adapter(ChatCompletionAdapter):
         )
 
     @classmethod
-    def create(cls, model: str, region: str, api_key: str):
+    def create(
+        cls, model: str, api_key: str, aws_client_config: AWSClientConfig
+    ):
         storage: Optional[FileStorage] = create_file_storage(api_key=api_key)
+        client_kwargs = aws_client_config.get_anthropic_bedrock_client_kwargs()
         return cls(
             model=model,
             storage=storage,
-            client=AsyncAnthropicBedrock(aws_region=region),
+            client=AsyncAnthropicBedrock(**client_kwargs),
         )

--- a/tests/unit_tests/test_aws_client_config_factory.py
+++ b/tests/unit_tests/test_aws_client_config_factory.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from unittest import mock
+
+import pytest
+
+from aidial_adapter_bedrock.aws_client_config import (
+    AWSClientConfigFactory,
+    AWSClientCredentials,
+)
+
+
+@dataclass
+class FakeRequest:
+    headers: dict[str, str]
+
+
+@pytest.mark.asyncio
+class TestAWSClientConfigFactory:
+    async def test__get_client_config__no_raw_upstream_config__default_region_in_config(
+        self,
+    ):
+        request = FakeRequest(headers={})
+
+        client_config = await AWSClientConfigFactory(
+            request=request
+        ).get_client_config()
+
+        assert client_config.region == "us-east-1"
+        assert client_config.credentials is None
+
+    async def test__get_client_config__region_provided__region_in_config(self):
+        raw_upstream_config = '{"region": "us-east-2"}'
+        request = FakeRequest(headers={AWSClientConfigFactory.RAW_UPSTREAM_CONFIG_HEADER_NAME: raw_upstream_config})
+
+        client_config = await AWSClientConfigFactory(
+            request=request,
+        ).get_client_config()
+
+        assert client_config.region == "us-east-2"
+        assert client_config.credentials is None
+
+    async def test__get_client_config__raw_upstream_config_with_key_credentials__key_in_config(
+        self,
+    ):
+        raw_upstream_config = '{"aws_access_key_id": "key_id", "aws_secret_access_key": "key"}'
+        request = FakeRequest(headers={AWSClientConfigFactory.RAW_UPSTREAM_CONFIG_HEADER_NAME: raw_upstream_config})
+
+        client_config = await AWSClientConfigFactory(
+            request=request,
+        ).get_client_config()
+
+        assert client_config.region == "us-east-1"
+        assert client_config.credentials.aws_access_key_id == "key_id"
+        assert client_config.credentials.aws_secret_access_key == "key"
+
+    @mock.patch.object(
+        AWSClientConfigFactory,
+        "_get_assumed_role_tmp_credentials",
+        return_value=AWSClientCredentials(
+            aws_access_key_id="key_id",
+            aws_secret_access_key="key",
+            aws_session_token="session_token",
+        ),
+    )
+    async def test__get_client_config__raw_upstream_config_with_role_arn__tmp_credentials_in_config(
+        self, _mock
+    ):
+        raw_upstream_config = '{"aws_assume_role_arn": "arn"}'
+        request = FakeRequest(headers={AWSClientConfigFactory.RAW_UPSTREAM_CONFIG_HEADER_NAME: raw_upstream_config})
+
+        client_config = await AWSClientConfigFactory(
+            request=request,
+        ).get_client_config()
+
+        assert client_config.region == "us-east-1"
+        assert client_config.credentials.aws_access_key_id == "key_id"
+        assert client_config.credentials.aws_secret_access_key == "key"
+        assert client_config.credentials.aws_session_token == "session_token"

--- a/tests/unit_tests/test_aws_client_config_factory.py
+++ b/tests/unit_tests/test_aws_client_config_factory.py
@@ -16,9 +16,12 @@ class FakeRequest:
 
 @pytest.mark.asyncio
 class TestAWSClientConfigFactory:
-    async def test__get_client_config__no_raw_upstream_config__default_region_in_config(
-        self,
-    ):
+    @staticmethod
+    def _get_request(raw_upstream_config):
+        header_name = AWSClientConfigFactory.UPSTREAM_CONFIG_HEADER_NAME
+        return FakeRequest(headers={header_name: raw_upstream_config})
+
+    async def test__get_client_config__default_region_in_config(self):
         request = FakeRequest(headers={})
 
         client_config = await AWSClientConfigFactory(
@@ -30,7 +33,7 @@ class TestAWSClientConfigFactory:
 
     async def test__get_client_config__region_provided__region_in_config(self):
         raw_upstream_config = '{"region": "us-east-2"}'
-        request = FakeRequest(headers={AWSClientConfigFactory.RAW_UPSTREAM_CONFIG_HEADER_NAME: raw_upstream_config})
+        request = self._get_request(raw_upstream_config)
 
         client_config = await AWSClientConfigFactory(
             request=request,
@@ -39,17 +42,18 @@ class TestAWSClientConfigFactory:
         assert client_config.region == "us-east-2"
         assert client_config.credentials is None
 
-    async def test__get_client_config__raw_upstream_config_with_key_credentials__key_in_config(
-        self,
-    ):
-        raw_upstream_config = '{"aws_access_key_id": "key_id", "aws_secret_access_key": "key"}'
-        request = FakeRequest(headers={AWSClientConfigFactory.RAW_UPSTREAM_CONFIG_HEADER_NAME: raw_upstream_config})
+    async def test__get_client_config__key_in_config(self):
+        raw_upstream_config = (
+            '{"aws_access_key_id": "key_id", "aws_secret_access_key": "key"}'
+        )
+        request = self._get_request(raw_upstream_config)
 
         client_config = await AWSClientConfigFactory(
             request=request,
         ).get_client_config()
 
         assert client_config.region == "us-east-1"
+        assert client_config.credentials is not None
         assert client_config.credentials.aws_access_key_id == "key_id"
         assert client_config.credentials.aws_secret_access_key == "key"
 
@@ -62,17 +66,18 @@ class TestAWSClientConfigFactory:
             aws_session_token="session_token",
         ),
     )
-    async def test__get_client_config__raw_upstream_config_with_role_arn__tmp_credentials_in_config(
+    async def test__get_client_config__role_arn__tmp_credentials_in_config(
         self, _mock
     ):
         raw_upstream_config = '{"aws_assume_role_arn": "arn"}'
-        request = FakeRequest(headers={AWSClientConfigFactory.RAW_UPSTREAM_CONFIG_HEADER_NAME: raw_upstream_config})
+        request = self._get_request(raw_upstream_config)
 
         client_config = await AWSClientConfigFactory(
             request=request,
         ).get_client_config()
 
         assert client_config.region == "us-east-1"
+        assert client_config.credentials is not None
         assert client_config.credentials.aws_access_key_id == "key_id"
         assert client_config.credentials.aws_secret_access_key == "key"
         assert client_config.credentials.aws_session_token == "session_token"


### PR DESCRIPTION
Resolves #126 

This PR allows to get AWS client config from "x-upstream-extra-data" header and use this config in AWS client for model calls.