### PR TITLE
feat: [Claude 3] failing when max_prompt_tokens is provided

### DIFF
--- a/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
@@ -82,6 +82,11 @@ class Adapter(ChatCompletionAdapter):
         params: ModelParameters,
         messages: List[Message],
     ):
+        if params.max_prompt_tokens is not None:
+            raise ValidationError(
+                "max_prompt_tokens request parameter is not supported"
+            )
+
         if len(messages) == 0:
             raise ValidationError("List of messages must not be empty")
 


### PR DESCRIPTION
Since Claude 3 adapter doesn't support prompt truncation yet, fail with an error instead of simply ignoring the parameter.