### PR TITLE
fix: supported multiple tool call messages for Claude

### DIFF
--- a/aidial_adapter_bedrock/dial_api/request.py
+++ b/aidial_adapter_bedrock/dial_api/request.py
@@ -69,23 +69,26 @@ class ModelParameters(BaseModel):
 def collect_text_content(
     content: MessageContentSpecialized, delimiter: str = "\n\n"
 ) -> str:
-
-    if content is None:
-        return ""
-
-    if isinstance(content, str):
-        return content
-
-    texts: List[str] = []
-    for part in content:
-        if isinstance(part, MessageContentTextPart):
-            texts.append(part.text)
-        else:
-            raise ValidationError(
-                "Can't extract text from a multi-modal content part"
-            )
-
-    return delimiter.join(texts)
+    match content:
+        case None:
+            return ""
+        case str():
+            return content
+        case list():
+            texts: List[str] = []
+            for part in content:
+                match part:
+                    case MessageContentTextPart(text=text):
+                        texts.append(text)
+                    case MessageContentImagePart():
+                        raise ValidationError(
+                            "Can't extract text from an image content part"
+                        )
+                    case _:
+                        assert_never(part)
+            return delimiter.join(texts)
+        case _:
+            assert_never(content)
 
 
 def to_message_content(content: MessageContentSpecialized) -> MessageContent:

--- a/aidial_adapter_bedrock/llm/consumer.py
+++ b/aidial_adapter_bedrock/llm/consumer.py
@@ -58,6 +58,11 @@ class Consumer(ABC):
     def create_function_call(self, function_call: FunctionCall):
         pass
 
+    @property
+    @abstractmethod
+    def has_function_call(self) -> bool:
+        pass
+
 
 class ChoiceConsumer(Consumer):
     usage: TokenUsage
@@ -134,3 +139,7 @@ class ChoiceConsumer(Consumer):
         self.choice.create_function_call(
             name=function_call.name, arguments=function_call.arguments
         )
+
+    @property
+    def has_function_call(self) -> bool:
+        return self.choice.has_function_call

--- a/aidial_adapter_bedrock/llm/model/claude/v3/tokenizer.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/tokenizer.py
@@ -30,6 +30,7 @@ import io
 import json
 import math
 from typing import (
+    Any,
     Awaitable,
     Callable,
     List,
@@ -220,8 +221,8 @@ async def _tokenize(
 
 def create_tokenizer(
     deployment: Claude3Deployment, params: ClaudeParameters
-) -> Callable[[List[ClaudeMessage]], Awaitable[int]]:
-    async def _tokenizer(messages: List[ClaudeMessage]) -> int:
-        return await _tokenize(deployment, params, messages)
+) -> Callable[[List[Tuple[ClaudeMessage, Any]]], Awaitable[int]]:
+    async def _tokenizer(messages) -> int:
+        return await _tokenize(deployment, params, [msg for msg, _ in messages])
 
     return _tokenizer

--- a/aidial_adapter_bedrock/llm/model/claude/v3/tools.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/tools.py
@@ -18,6 +18,7 @@ from aidial_adapter_bedrock.llm.message import (
     ToolMessage,
 )
 from aidial_adapter_bedrock.llm.tools.tools_config import ToolsMode
+from aidial_adapter_bedrock.utils.log_config import bedrock_logger as log
 
 
 def to_dial_function_call(block: ToolUseBlock) -> FunctionCall:
@@ -40,7 +41,13 @@ def process_tools_block(
         case ToolsMode.TOOLS:
             consumer.create_function_tool_call(to_dial_tool_call(block))
         case ToolsMode.FUNCTIONS:
-            consumer.create_function_call(to_dial_function_call(block))
+            if consumer.has_function_call:
+                log.warning(
+                    "The model generated more than one tool call. "
+                    "Only the first one will be taken in to account."
+                )
+            else:
+                consumer.create_function_call(to_dial_function_call(block))
         case None:
             raise ValidationError(
                 "A model has called a tool, but no tools were given to the model in the first place."

--- a/aidial_adapter_bedrock/utils/list.py
+++ b/aidial_adapter_bedrock/utils/list.py
@@ -1,11 +1,39 @@
-from typing import Container, List, TypeVar
+from typing import Any, Callable, Container, List, TypeVar
 
-T = TypeVar("T")
+_T = TypeVar("_T")
+_V = TypeVar("_V")
 
 
-def select_by_indices(lst: List[T], indices: Container[int]) -> List[T]:
+def select_by_indices(lst: List[_T], indices: Container[int]) -> List[_T]:
     return [elem for idx, elem in enumerate(lst) if idx in indices]
 
 
-def omit_by_indices(lst: List[T], indices: Container[int]) -> List[T]:
+def omit_by_indices(lst: List[_T], indices: Container[int]) -> List[_T]:
     return [elem for idx, elem in enumerate(lst) if idx not in indices]
+
+
+def group_by(
+    lst: List[_T],
+    key: Callable[[_T], Any],
+    init: Callable[[_T], _V],
+    merge: Callable[[_V, _T], _V],
+) -> List[_V]:
+
+    def _gen():
+        if not lst:
+            return
+
+        prev_val = init(lst[0])
+        prev_key = key(lst[0])
+
+        for elem in lst[1:]:
+            if prev_key == key(elem):
+                prev_val = merge(prev_val, elem)
+            else:
+                yield prev_val
+                prev_val = init(elem)
+                prev_key = key(elem)
+
+        yield prev_val
+
+    return list(_gen())

--- a/aidial_adapter_bedrock/utils/list_projection.py
+++ b/aidial_adapter_bedrock/utils/list_projection.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass, field
+from typing import Generic, Iterable, List, Self, Set, Tuple, TypeVar
+
+_T = TypeVar("_T")
+
+
+@dataclass
+class ListProjection(Generic[_T]):
+    """
+    The class presents a transformation of the original list which may
+    include merge, removal and addition of the original list elements.
+
+    Each derivative element is mapped onto a subset of original elements.
+    The subsets must be disjoint.
+    """
+
+    list: List[Tuple[_T, Set[int]]] = field(default_factory=list)
+
+    @property
+    def raw_list(self) -> List[_T]:
+        return [msg for msg, _ in self.list]
+
+    def to_original_indices(self, idx: int | Iterable[int]) -> Set[int]:
+        return {
+            orig_index
+            for index in _to_set(idx)
+            for orig_index in self.list[index][1]
+        }
+
+    def append(self, elem: _T, idx: int | Iterable[int]) -> Self:
+        self.list.append((elem, _to_set(idx)))
+        return self
+
+
+def _to_set(idx: int | Iterable[int]) -> Set[int]:
+    return {idx} if isinstance(idx, int) else set(idx)


### PR DESCRIPTION
The bug manifests itself in the following request to `anthropic.claude-3-haiku-20240307-v1:0`:

<details>
<summary>Request</summary>

```json
{
  "messages": [
    {
      "role": "system",
      "content": "You are a helpful assistant."
    },
    {
      "role": "user",
      "content": "What is the weather in Minsk and in Paris? specify temperature in Celsius."
    },
    {
      "role": "assistant",
      "content": "Certainly! I'll check the current weather for both Minsk and Paris, specifying the temperature in Celsius. To do this, I'll need to use the get_current_weather function twice, once for each city. Let me fetch that information for you.",
      "tool_calls": [
        {
          "id": "toolu_bdrk_013wC4tXP8jhxSr3zBCcqrBH",
          "type": "function",
          "function": {
            "name": "get_current_weather",
            "arguments": "{\"location\": \"Minsk, Belarus\", \"unit\": \"celsius\"}"
          }
        },
        {
          "id": "toolu_bdrk_01Jo6uCcM1auup6dUZQmaBnA",
          "type": "function",
          "function": {
            "name": "get_current_weather",
            "arguments": "{\"location\": \"Paris, France\", \"unit\": \"celsius\"}"
          }
        }
      ]
    },
    {
      "role": "tool",
      "content": "20 celsius",
      "tool_call_id": "toolu_bdrk_013wC4tXP8jhxSr3zBCcqrBH"
    },
    {
      "role": "tool",
      "content": "30 celsius",
      "tool_call_id": "toolu_bdrk_01Jo6uCcM1auup6dUZQmaBnA"
    }
  ],
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "get_current_weather",
        "description": "Get the current weather in a given location",
        "parameters": {
          "type": "object",
          "properties": {
            "location": {
              "type": "string",
              "description": "The city and state, e.g. San Francisco, CA"
            },
            "unit": {
              "type": "string",
              "enum": [
                "celsius",
                "fahrenheit"
              ]
            }
          },
          "required": [
            "location"
          ]
        }
      }
    }
  ],
  "tool_choice": "auto",
  "temperature": 0.1,
  "stream": false
}
```

</details>

failing with the validation error coming from the model itself:

```
Error code: 400
{'message': \"messages.2: the following `tool_use` ids were not found in `tool_result` blocks: {'toolu_bdrk_01Jo6uCcM1auup6dUZQmaBnA'}\"}",
```

The cause is that **two** consequent `tool` messages in the original request are translated to **two** Claude messages with `tool_result`:

```json
[
  {
    "role": "user",
    "content": [
      {
        "type": "tool_result",
        "tool_use_id": "toolu_01RyoTtdXMzyGM9iR818LwAv",
        "content": "25 celsius"
      }
    ]
  },
  {
    "role": "user",
    "content": [
      {
        "type": "tool_result",
        "tool_use_id": "toolu_02RyoTtdXMzyGM9iR818LwAv",
        "content": "35 celsius"
      }
    ]
  }
]
```

it happens here:

https://github.com/epam/ai-dial-adapter-bedrock/blob/cab277e1bc9470721825d901be74c2680a3bd5e6/aidial_adapter_bedrock/llm/model/claude/v3/converters.py#L187-L193

and this is what Claude doesn't like.

Instead, the message should be merged into one like this:

```json
[
  {
    "role": "user",
    "content": [
      {
        "type": "tool_result",
        "tool_use_id": "toolu_01RyoTtdXMzyGM9iR818LwAv",
        "content": "25 celsius"
      },
      {
        "type": "tool_result",
        "tool_use_id": "toolu_02RyoTtdXMzyGM9iR818LwAv",
        "content": "35 celsius"
      }
    ]
  }
]
```

The proposed generic solution - is to merge adjacent messages with the same role into one.

The truncate prompt algo should be adjusted accordingly to take into account the consolidated blocks of messages and remove them as a whole.