### PR TITLE
fix: fixed bug in claude3 tokenizer

### DIFF
--- a/aidial_adapter_bedrock/dial_api/storage.py
+++ b/aidial_adapter_bedrock/dial_api/storage.py
@@ -40,8 +40,9 @@ class FileStorage(BaseModel):
                 headers=self.auth_headers,
             ) as response:
                 response.raise_for_status()
-                self.bucket = await response.json()
+                self.bucket = bucket = await response.json()
                 log.debug(f"bucket: {self.bucket}")
+                return bucket
 
         return self.bucket
 

--- a/aidial_adapter_bedrock/llm/model/claude/v3/tokenizer.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/tokenizer.py
@@ -173,8 +173,8 @@ def _tokenize_tool_system_message(
         ):
             return 294 if tool_choice == "auto" else 261
         case (
-            ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_5_SONNET_V2,
-            ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_5_SONNET_V2_US,
+            ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_5_SONNET_V2
+            | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_5_SONNET_V2_US
         ):
             return 346 if tool_choice == "auto" else 313
         case (

--- a/poetry.lock
+++ b/poetry.lock
@@ -1990,21 +1990,23 @@ files = [
 
 [[package]]
 name = "pyright"
-version = "1.1.324"
+version = "1.1.389"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.324-py3-none-any.whl", hash = "sha256:0edb712afbbad474e347de12ca1bd9368aa85d3365a1c7b795012e48e6a65111"},
-    {file = "pyright-1.1.324.tar.gz", hash = "sha256:0c48e3bca3d081bba0dddd0c1f075aaa965c59bba691f7b9bd9d73a98e44e0cf"},
+    {file = "pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60"},
+    {file = "pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220"},
 ]
 
 [package.dependencies]
 nodeenv = ">=1.6.0"
+typing-extensions = ">=4.1"
 
 [package.extras]
-all = ["twine (>=3.4.1)"]
+all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
 dev = ["twine (>=3.4.1)"]
+nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"
@@ -2652,4 +2654,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11,<4.0"
-content-hash = "a99ddf2ca2b4ce8adf619fb1b52c1ec3d62d476cad7723c362830d8fe6a22741"
+content-hash = "4057274f92b17f20c15ae44e88300e8a2b275143ce9e76fd3cb14b1d5475b973"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ pytest-dotenv = "^0.5.2"
 pytest-xdist = "^3.5.0"
 
 [tool.poetry.group.lint.dependencies]
-pyright = "1.1.324"
+pyright = "1.1.389"
 black = "24.3.0"
 isort = "5.12.0"
 autoflake = "2.2.0"


### PR DESCRIPTION
Migrated from pyright 1.1.324 to 1.1.389 to catch the bug during type checking.