### PR TITLE
chore: refactor chat emulator

### DIFF
--- a/aidial_adapter_bedrock/llm/chat_emulator.py
+++ b/aidial_adapter_bedrock/llm/chat_emulator.py
@@ -29,9 +29,9 @@ class CueMapping(TypedDict):
 
 class BasicChatEmulator(ChatEmulator):
     prelude_template: Optional[str]
-    add_cue: Callable[[Message, int], bool]
-    add_invitation_cue: bool
-    fallback_to_completion: bool
+    should_prefix_with_cue: Callable[[Message, int], bool]
+    should_add_invitation_cue: bool
+    should_fallback_to_completion: bool
     cues: CueMapping
     separator: str
 
@@ -55,7 +55,7 @@ class BasicChatEmulator(ChatEmulator):
     def _format_message(self, message: Message, idx: int) -> str:
         cue = self._get_cue(message)
 
-        if cue is None or not self.add_cue(message, idx):
+        if cue is None or not self.should_prefix_with_cue(message, idx):
             cue_prefix = ""
         else:
             cue_prefix = cue + " "
@@ -69,7 +69,7 @@ class BasicChatEmulator(ChatEmulator):
 
     def display(self, messages: List[Message]) -> Tuple[str, List[str]]:
         if (
-            self.fallback_to_completion
+            self.should_fallback_to_completion
             and len(messages) == 1
             and messages[0].role == Role.USER
         ):
@@ -83,7 +83,7 @@ class BasicChatEmulator(ChatEmulator):
         for message in messages:
             ret.append(self._format_message(message, len(ret)))
 
-        if self.add_invitation_cue:
+        if self.should_add_invitation_cue:
             ret.append(
                 self._format_message(
                     Message(role=Role.ASSISTANT, content=""), len(ret)
@@ -106,9 +106,9 @@ The messages from you start with "{human}".
 Reply to the last message from the user taking into account the preceding dialog history.
 ====================
 """.strip(),
-    add_cue=lambda *_: True,
-    add_invitation_cue=True,
-    fallback_to_completion=True,
+    should_prefix_with_cue=lambda *_: True,
+    should_add_invitation_cue=True,
+    should_fallback_to_completion=True,
     cues=CueMapping(
         system="Human:",
         human="Human:",

--- a/aidial_adapter_bedrock/llm/chat_emulator.py
+++ b/aidial_adapter_bedrock/llm/chat_emulator.py
@@ -1,18 +1,19 @@
 from abc import ABC, abstractmethod
-from typing import Callable, List, Optional, Tuple, TypedDict
+from typing import AsyncIterator, Callable, List, Optional, Tuple, TypedDict
 
+from aidial_sdk.chat_completion import Message, Role
 from pydantic import BaseModel
 
-from aidial_adapter_bedrock.llm.message import (
-    AIRegularMessage,
-    BaseMessage,
-    HumanRegularMessage,
+import aidial_adapter_bedrock.utils.stream as stream_utils
+from aidial_adapter_bedrock.dial_api.request import (
+    ModelParameters,
+    collect_text_content,
 )
 
 
 class ChatEmulator(ABC, BaseModel):
     @abstractmethod
-    def display(self, messages: List[BaseMessage]) -> Tuple[str, List[str]]:
+    def display(self, messages: List[Message]) -> Tuple[str, List[str]]:
         """Returns a prompt string and a list of stop sequences."""
 
     @abstractmethod
@@ -28,7 +29,7 @@ class CueMapping(TypedDict):
 
 class BasicChatEmulator(ChatEmulator):
     prelude_template: Optional[str]
-    add_cue: Callable[[BaseMessage, int], bool]
+    add_cue: Callable[[Message, int], bool]
     add_invitation_cue: bool
     fallback_to_completion: bool
     cues: CueMapping
@@ -40,17 +41,18 @@ class BasicChatEmulator(ChatEmulator):
             return None
         return self.prelude_template.format(**self.cues)
 
-    def _get_cue(self, message: BaseMessage) -> Optional[str]:
-        if isinstance(message, HumanRegularMessage):
-            return self.cues["human"]
-        elif isinstance(message, AIRegularMessage):
-            return self.cues["ai"]
-        elif isinstance(message, BaseMessage):
-            return self.cues["system"]
-        else:
-            raise ValueError(f"Unknown message type: {message.type}")
+    def _get_cue(self, message: Message) -> Optional[str]:
+        match message.role:
+            case Role.USER:
+                return self.cues["human"]
+            case Role.ASSISTANT:
+                return self.cues["ai"]
+            case Role.SYSTEM:
+                return self.cues["system"]
+            case _:
+                raise ValueError(f"Unexpected message type: {message.role}")
 
-    def _format_message(self, message: BaseMessage, idx: int) -> str:
+    def _format_message(self, message: Message, idx: int) -> str:
         cue = self._get_cue(message)
 
         if cue is None or not self.add_cue(message, idx):
@@ -58,18 +60,20 @@ class BasicChatEmulator(ChatEmulator):
         else:
             cue_prefix = cue + " "
 
-        return (cue_prefix + message.text_content.lstrip()).rstrip()
+        return (
+            cue_prefix + collect_text_content(message.content).lstrip()
+        ).rstrip()
 
     def get_ai_cue(self) -> Optional[str]:
         return self.cues["ai"]
 
-    def display(self, messages: List[BaseMessage]) -> Tuple[str, List[str]]:
+    def display(self, messages: List[Message]) -> Tuple[str, List[str]]:
         if (
             self.fallback_to_completion
             and len(messages) == 1
-            and isinstance(messages[0], HumanRegularMessage)
+            and messages[0].role == Role.USER
         ):
-            return messages[0].text_content, []
+            return collect_text_content(messages[0].content), []
 
         ret: List[str] = []
 
@@ -81,7 +85,9 @@ class BasicChatEmulator(ChatEmulator):
 
         if self.add_invitation_cue:
             ret.append(
-                self._format_message(AIRegularMessage(content=""), len(ret))
+                self._format_message(
+                    Message(role=Role.ASSISTANT, content=""), len(ret)
+                )
             )
 
         stop_sequences: List[str] = []
@@ -110,3 +116,28 @@ Reply to the last message from the user taking into account the preceding dialog
     ),
     separator="\n\n",
 )
+
+
+def post_process_completion_stream(
+    params: ModelParameters,
+    emulator: ChatEmulator,
+    stream: AsyncIterator[str],
+) -> AsyncIterator[str]:
+    # Removing leading spaces
+    stream = stream_utils.lstrip(stream)
+
+    # Model may occasionally start responding with its cue.
+    ai_cue = emulator.get_ai_cue()
+    if ai_cue is not None:
+        stream = stream_utils.remove_prefix(stream, ai_cue)
+        stream = stream_utils.lstrip(stream)
+
+    # The model may not support stop sequences, so do it manually
+    if params.stop:
+        stream = stream_utils.stop_at(stream, params.stop)
+
+    # After all the post processing, the stream may become empty.
+    # To avoid this, add a space to the stream.
+    stream = stream_utils.ensure_not_empty(stream, " ")
+
+    return stream

--- a/aidial_adapter_bedrock/llm/chat_model.py
+++ b/aidial_adapter_bedrock/llm/chat_model.py
@@ -101,7 +101,7 @@ class TextCompletionAdapter(ChatCompletionAdapter):
 
         messages = self.preprocess_messages(messages)
         tools_emulator = self.tools_emulator(params.tool_config)
-        base_messages = tools_emulator.parse_dial_messages(messages)
+        base_messages = tools_emulator.prepare_messages(messages)
         tool_stop_sequences = tools_emulator.get_stop_sequences()
 
         prompt = await self.truncate_and_linearize_messages(
@@ -164,7 +164,7 @@ class PseudoChatModel(TextCompletionAdapter):
     ) -> int:
         messages = self.preprocess_messages(messages)
         tools_emulator = self.tools_emulator(params.tool_config)
-        messages = tools_emulator.parse_dial_messages(messages)
+        messages = tools_emulator.prepare_messages(messages)
         return await self.tokenize_messages(messages)
 
     async def count_completion_tokens(self, string: str) -> int:

--- a/aidial_adapter_bedrock/llm/chat_model.py
+++ b/aidial_adapter_bedrock/llm/chat_model.py
@@ -12,7 +12,10 @@ from aidial_adapter_bedrock.dial_api.request import (
 from aidial_adapter_bedrock.llm.chat_emulator import ChatEmulator
 from aidial_adapter_bedrock.llm.consumer import Consumer
 from aidial_adapter_bedrock.llm.errors import ValidationError
-from aidial_adapter_bedrock.llm.tools.emulator import ToolsEmulator
+from aidial_adapter_bedrock.llm.tools.emulator import (
+    ToolsEmulator,
+    emulate_tools,
+)
 from aidial_adapter_bedrock.llm.tools.tools_config import ToolsConfig
 from aidial_adapter_bedrock.llm.truncate_prompt import (
     DiscardedMessages,
@@ -101,7 +104,7 @@ class TextCompletionAdapter(ChatCompletionAdapter):
 
         messages = self.preprocess_messages(messages)
         tools_emulator = self.tools_emulator(params.tool_config)
-        base_messages = tools_emulator.prepare_messages(messages)
+        base_messages = emulate_tools(tools_emulator, messages)
         tool_stop_sequences = tools_emulator.get_stop_sequences()
 
         prompt = await self.truncate_and_linearize_messages(
@@ -164,7 +167,7 @@ class PseudoChatModel(TextCompletionAdapter):
     ) -> int:
         messages = self.preprocess_messages(messages)
         tools_emulator = self.tools_emulator(params.tool_config)
-        messages = tools_emulator.prepare_messages(messages)
+        messages = emulate_tools(tools_emulator, messages)
         return await self.tokenize_messages(messages)
 
     async def count_completion_tokens(self, string: str) -> int:

--- a/aidial_adapter_bedrock/llm/chat_model.py
+++ b/aidial_adapter_bedrock/llm/chat_model.py
@@ -1,11 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Any, AsyncIterator, Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
 from aidial_sdk.chat_completion import Message, Role
 from pydantic import BaseModel
 from typing_extensions import override
 
-import aidial_adapter_bedrock.utils.stream as stream_utils
 from aidial_adapter_bedrock.dial_api.request import (
     ModelParameters,
     collect_text_content,

--- a/aidial_adapter_bedrock/llm/chat_model.py
+++ b/aidial_adapter_bedrock/llm/chat_model.py
@@ -13,7 +13,6 @@ from aidial_adapter_bedrock.dial_api.request import (
 from aidial_adapter_bedrock.llm.chat_emulator import ChatEmulator
 from aidial_adapter_bedrock.llm.consumer import Consumer
 from aidial_adapter_bedrock.llm.errors import ValidationError
-from aidial_adapter_bedrock.llm.message import BaseMessage, SystemMessage
 from aidial_adapter_bedrock.llm.tools.emulator import ToolsEmulator
 from aidial_adapter_bedrock.llm.tools.tools_config import ToolsConfig
 from aidial_adapter_bedrock.llm.truncate_prompt import (
@@ -82,7 +81,7 @@ class TextCompletionAdapter(ChatCompletionAdapter):
 
     @abstractmethod
     async def truncate_and_linearize_messages(
-        self, messages: List[BaseMessage], max_prompt_tokens: Optional[int]
+        self, messages: List[Message], max_prompt_tokens: Optional[int]
     ) -> TextCompletionPrompt:
         pass
 
@@ -143,10 +142,8 @@ def keep_last(messages: List[Any], idx: int) -> bool:
     return idx == len(messages) - 1
 
 
-def keep_last_and_system_messages(
-    messages: List[BaseMessage], idx: int
-) -> bool:
-    return isinstance(messages[idx], SystemMessage) or keep_last(messages, idx)
+def keep_last_and_system_messages(messages: List[Message], idx: int) -> bool:
+    return messages[idx].role == Role.SYSTEM or keep_last(messages, idx)
 
 
 def trivial_partitioner(messages: List[Any]) -> List[int]:
@@ -161,25 +158,25 @@ def turn_based_partitioner(messages: List[Any]) -> List[int]:
 class PseudoChatModel(TextCompletionAdapter):
     chat_emulator: ChatEmulator
     tokenize_string: Callable[[str], int]
-    partitioner: Callable[[List[BaseMessage]], List[int]]
+    partitioner: Callable[[List[Message]], List[int]]
 
     async def count_prompt_tokens(
         self, params: ModelParameters, messages: List[Message]
     ) -> int:
         messages = self.preprocess_messages(messages)
         tools_emulator = self.tools_emulator(params.tool_config)
-        base_messages = tools_emulator.parse_dial_messages(messages)
-        return await self.tokenize_messages(base_messages)
+        messages = tools_emulator.parse_dial_messages(messages)
+        return await self.tokenize_messages(messages)
 
     async def count_completion_tokens(self, string: str) -> int:
         return self.tokenize_string(string)
 
-    async def tokenize_messages(self, messages: List[BaseMessage]) -> int:
+    async def tokenize_messages(self, messages: List[Message]) -> int:
         return self.tokenize_string(self.chat_emulator.display(messages)[0])
 
     @override
     async def truncate_and_linearize_messages(
-        self, messages: List[BaseMessage], max_prompt_tokens: Optional[int]
+        self, messages: List[Message], max_prompt_tokens: Optional[int]
     ) -> TextCompletionPrompt:
         discarded_messages, messages = await truncate_prompt(
             messages=messages,
@@ -200,28 +197,3 @@ class PseudoChatModel(TextCompletionAdapter):
             stop_sequences=stop_sequences,
             discarded_messages=discarded_messages,
         )
-
-    @staticmethod
-    def post_process_stream(
-        stream: AsyncIterator[str],
-        params: ModelParameters,
-        emulator: ChatEmulator,
-    ) -> AsyncIterator[str]:
-        # Removing leading spaces
-        stream = stream_utils.lstrip(stream)
-
-        # Model may occasionally start responding with its cue.
-        ai_cue = emulator.get_ai_cue()
-        if ai_cue is not None:
-            stream = stream_utils.remove_prefix(stream, ai_cue)
-            stream = stream_utils.lstrip(stream)
-
-        # The model may not support stop sequences, so do it manually
-        if params.stop:
-            stream = stream_utils.stop_at(stream, params.stop)
-
-        # After all the post processing, the stream may become empty.
-        # To avoid this, add a space to the stream.
-        stream = stream_utils.ensure_not_empty(stream, " ")
-
-        return stream

--- a/aidial_adapter_bedrock/llm/model/amazon.py
+++ b/aidial_adapter_bedrock/llm/model/amazon.py
@@ -7,7 +7,10 @@ from typing_extensions import override
 from aidial_adapter_bedrock.bedrock import Bedrock
 from aidial_adapter_bedrock.dial_api.request import ModelParameters
 from aidial_adapter_bedrock.dial_api.token_usage import TokenUsage
-from aidial_adapter_bedrock.llm.chat_emulator import default_emulator
+from aidial_adapter_bedrock.llm.chat_emulator import (
+    default_emulator,
+    post_process_completion_stream,
+)
 from aidial_adapter_bedrock.llm.chat_model import (
     PseudoChatModel,
     trivial_partitioner,
@@ -145,7 +148,9 @@ class AmazonAdapter(PseudoChatModel):
             )
             stream = response_to_stream(response, usage)
 
-        stream = self.post_process_stream(stream, params, self.chat_emulator)
+        stream = post_process_completion_stream(
+            params, self.chat_emulator, stream
+        )
 
         async for content in stream:
             consumer.append_content(content)

--- a/aidial_adapter_bedrock/llm/model/claude/v1_v2/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v1_v2/adapter.py
@@ -79,9 +79,9 @@ def get_anthropic_emulator(is_system_message_supported: bool) -> ChatEmulator:
 
     return BasicChatEmulator(
         prelude_template=None,
-        add_cue=add_cue,
-        add_invitation_cue=True,
-        fallback_to_completion=False,
+        should_prefix_with_cue=add_cue,
+        should_add_invitation_cue=True,
+        should_fallback_to_completion=False,
         cues=CueMapping(
             system=anthropic.HUMAN_PROMPT.strip(),
             human=anthropic.HUMAN_PROMPT.strip(),

--- a/aidial_adapter_bedrock/llm/model/claude/v1_v2/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v1_v2/adapter.py
@@ -1,6 +1,7 @@
 from typing import Any, AsyncIterator, Dict
 
 import anthropic
+from aidial_sdk.chat_completion import Message, Role
 from anthropic._tokenizers import async_get_tokenizer
 from tokenizers import Tokenizer
 
@@ -19,7 +20,6 @@ from aidial_adapter_bedrock.llm.chat_model import (
     trivial_partitioner,
 )
 from aidial_adapter_bedrock.llm.consumer import Consumer
-from aidial_adapter_bedrock.llm.message import BaseMessage, SystemMessage
 from aidial_adapter_bedrock.llm.model.conf import DEFAULT_MAX_TOKENS_ANTHROPIC
 from aidial_adapter_bedrock.llm.tools.claude_emulator import (
     legacy_tools_emulator,
@@ -68,10 +68,10 @@ async def response_to_stream(response: dict) -> AsyncIterator[str]:
 
 
 def get_anthropic_emulator(is_system_message_supported: bool) -> ChatEmulator:
-    def add_cue(message: BaseMessage, idx: int) -> bool:
+    def add_cue(message: Message, idx: int) -> bool:
         if (
             idx == 0
-            and isinstance(message, SystemMessage)
+            and message.role == Role.SYSTEM
             and is_system_message_supported
         ):
             return False

--- a/aidial_adapter_bedrock/llm/model/cohere.py
+++ b/aidial_adapter_bedrock/llm/model/cohere.py
@@ -126,9 +126,9 @@ async def response_to_stream(
 
 cohere_emulator = BasicChatEmulator(
     prelude_template=None,
-    add_cue=lambda _, idx: idx > 0,
-    add_invitation_cue=False,
-    fallback_to_completion=False,
+    should_prefix_with_cue=lambda _, idx: idx > 0,
+    should_add_invitation_cue=False,
+    should_fallback_to_completion=False,
     cues=CueMapping(
         system="User:",
         human="User:",

--- a/aidial_adapter_bedrock/llm/model/cohere.py
+++ b/aidial_adapter_bedrock/llm/model/cohere.py
@@ -13,6 +13,7 @@ from aidial_adapter_bedrock.dial_api.token_usage import TokenUsage
 from aidial_adapter_bedrock.llm.chat_emulator import (
     BasicChatEmulator,
     CueMapping,
+    post_process_completion_stream,
 )
 from aidial_adapter_bedrock.llm.chat_model import (
     PseudoChatModel,
@@ -179,7 +180,9 @@ class CohereAdapter(PseudoChatModel):
             )
             stream = response_to_stream(response, usage)
 
-        stream = self.post_process_stream(stream, params, self.chat_emulator)
+        stream = post_process_completion_stream(
+            params, self.chat_emulator, stream
+        )
 
         async for content in stream:
             consumer.append_content(content)

--- a/aidial_adapter_bedrock/llm/tools/emulator.py
+++ b/aidial_adapter_bedrock/llm/tools/emulator.py
@@ -55,11 +55,8 @@ class ToolsEmulator(ABC, BaseModel):
         Recognizing function/tool call from a model response.
         """
 
-    def parse_dial_messages(self, messages: List[Message]) -> List[Message]:
-        parsed_messages = list(map(parse_dial_message, messages))
-        base_messages = self.convert_to_base_messages(parsed_messages)
+    def prepare_messages(self, messages: List[Message]) -> List[Message]:
+        base_and_tool_messages = [parse_dial_message(msg) for msg in messages]
+        base_messages = self.convert_to_base_messages(base_and_tool_messages)
         base_messages = self.add_tool_declarations(base_messages)
-        dial_messages = [
-            base_message.to_message() for base_message in base_messages
-        ]
-        return dial_messages
+        return [msg.to_message() for msg in base_messages]

--- a/aidial_adapter_bedrock/llm/tools/emulator.py
+++ b/aidial_adapter_bedrock/llm/tools/emulator.py
@@ -55,7 +55,11 @@ class ToolsEmulator(ABC, BaseModel):
         Recognizing function/tool call from a model response.
         """
 
-    def parse_dial_messages(self, messages: List[Message]) -> List[BaseMessage]:
+    def parse_dial_messages(self, messages: List[Message]) -> List[Message]:
         parsed_messages = list(map(parse_dial_message, messages))
         base_messages = self.convert_to_base_messages(parsed_messages)
-        return self.add_tool_declarations(base_messages)
+        base_messages = self.add_tool_declarations(base_messages)
+        dial_messages = [
+            base_message.to_message() for base_message in base_messages
+        ]
+        return dial_messages

--- a/aidial_adapter_bedrock/llm/tools/emulator.py
+++ b/aidial_adapter_bedrock/llm/tools/emulator.py
@@ -55,8 +55,11 @@ class ToolsEmulator(ABC, BaseModel):
         Recognizing function/tool call from a model response.
         """
 
-    def prepare_messages(self, messages: List[Message]) -> List[Message]:
-        base_and_tool_messages = [parse_dial_message(msg) for msg in messages]
-        base_messages = self.convert_to_base_messages(base_and_tool_messages)
-        base_messages = self.add_tool_declarations(base_messages)
-        return [msg.to_message() for msg in base_messages]
+
+def emulate_tools(
+    emulator: ToolsEmulator, messages: List[Message]
+) -> List[Message]:
+    base_and_tool_messages = [parse_dial_message(msg) for msg in messages]
+    base_messages = emulator.convert_to_base_messages(base_and_tool_messages)
+    base_messages = emulator.add_tool_declarations(base_messages)
+    return [msg.to_message() for msg in base_messages]

--- a/aidial_adapter_bedrock/utils/list_projection.py
+++ b/aidial_adapter_bedrock/utils/list_projection.py
@@ -7,7 +7,7 @@ _T = TypeVar("_T")
 @dataclass
 class ListProjection(Generic[_T]):
     """
-    The class presents a transformation of the original list which may
+    The class represents a transformation of the original list which may
     include merge, removal and addition of the original list elements.
 
     Each derivative element is mapped onto a subset of original elements.

--- a/tests/unit_tests/chat_emulation/test_claude_chat.py
+++ b/tests/unit_tests/chat_emulation/test_claude_chat.py
@@ -17,7 +17,7 @@ def test_construction(is_system_message_supported: bool):
 
     text, stop_sequences = get_anthropic_emulator(
         is_system_message_supported
-    ).display((messages))
+    ).display(messages)
 
     sys_message_prefix = "Human: " if not is_system_message_supported else ""
 

--- a/tests/unit_tests/chat_emulation/test_claude_chat.py
+++ b/tests/unit_tests/chat_emulation/test_claude_chat.py
@@ -1,17 +1,14 @@
-from typing import List
-
 import pytest
 
-from aidial_adapter_bedrock.llm.message import MessageABC
 from aidial_adapter_bedrock.llm.model.claude.v1_v2.adapter import (
     get_anthropic_emulator,
 )
-from tests.utils.messages import ai, sys, to_sdk_messages, user
+from tests.utils.messages import ai, sys, user
 
 
 @pytest.mark.parametrize("is_system_message_supported", [False, True])
 def test_construction(is_system_message_supported: bool):
-    messages: List[MessageABC] = [
+    messages = [
         sys(" system message1 "),
         user("  human message1  "),
         ai("     ai message1     "),
@@ -20,7 +17,7 @@ def test_construction(is_system_message_supported: bool):
 
     text, stop_sequences = get_anthropic_emulator(
         is_system_message_supported
-    ).display(to_sdk_messages(messages))
+    ).display((messages))
 
     sys_message_prefix = "Human: " if not is_system_message_supported else ""
 

--- a/tests/unit_tests/chat_emulation/test_claude_chat.py
+++ b/tests/unit_tests/chat_emulation/test_claude_chat.py
@@ -1,14 +1,17 @@
+from typing import List
+
 import pytest
 
+from aidial_adapter_bedrock.llm.message import MessageABC
 from aidial_adapter_bedrock.llm.model.claude.v1_v2.adapter import (
     get_anthropic_emulator,
 )
-from tests.utils.messages import ai, sys, user
+from tests.utils.messages import ai, sys, to_sdk_messages, user
 
 
 @pytest.mark.parametrize("is_system_message_supported", [False, True])
 def test_construction(is_system_message_supported: bool):
-    messages = [
+    messages: List[MessageABC] = [
         sys(" system message1 "),
         user("  human message1  "),
         ai("     ai message1     "),
@@ -17,7 +20,7 @@ def test_construction(is_system_message_supported: bool):
 
     text, stop_sequences = get_anthropic_emulator(
         is_system_message_supported
-    ).display(messages)
+    ).display(to_sdk_messages(messages))
 
     sys_message_prefix = "Human: " if not is_system_message_supported else ""
 

--- a/tests/unit_tests/chat_emulation/test_cohere_chat.py
+++ b/tests/unit_tests/chat_emulation/test_cohere_chat.py
@@ -1,30 +1,27 @@
-from typing import List
-
-from aidial_adapter_bedrock.llm.message import MessageABC
 from aidial_adapter_bedrock.llm.model.cohere import cohere_emulator
-from tests.utils.messages import ai, sys, to_sdk_messages, user
+from tests.utils.messages import ai, sys, user
 
 
 def test_construction1():
-    messages: List[MessageABC] = [
+    messages = [
         user("  human message1  "),
     ]
 
-    text, stop_sequences = cohere_emulator.display(to_sdk_messages(messages))
+    text, stop_sequences = cohere_emulator.display((messages))
 
     assert stop_sequences == ["\nUser:"]
     assert text == "human message1"
 
 
 def test_construction2():
-    messages: List[MessageABC] = [
+    messages = [
         sys(" system message1 "),
         user("  human message1  "),
         ai("     ai message1     "),
         user("  human message2  "),
     ]
 
-    text, stop_sequences = cohere_emulator.display(to_sdk_messages(messages))
+    text, stop_sequences = cohere_emulator.display((messages))
 
     assert stop_sequences == ["\nUser:"]
     assert text == "\n".join(

--- a/tests/unit_tests/chat_emulation/test_cohere_chat.py
+++ b/tests/unit_tests/chat_emulation/test_cohere_chat.py
@@ -7,7 +7,7 @@ def test_construction1():
         user("  human message1  "),
     ]
 
-    text, stop_sequences = cohere_emulator.display((messages))
+    text, stop_sequences = cohere_emulator.display(messages)
 
     assert stop_sequences == ["\nUser:"]
     assert text == "human message1"
@@ -21,7 +21,7 @@ def test_construction2():
         user("  human message2  "),
     ]
 
-    text, stop_sequences = cohere_emulator.display((messages))
+    text, stop_sequences = cohere_emulator.display(messages)
 
     assert stop_sequences == ["\nUser:"]
     assert text == "\n".join(

--- a/tests/unit_tests/chat_emulation/test_cohere_chat.py
+++ b/tests/unit_tests/chat_emulation/test_cohere_chat.py
@@ -1,30 +1,30 @@
 from typing import List
 
-from aidial_adapter_bedrock.llm.message import BaseMessage
+from aidial_adapter_bedrock.llm.message import MessageABC
 from aidial_adapter_bedrock.llm.model.cohere import cohere_emulator
-from tests.utils.messages import ai, sys, user
+from tests.utils.messages import ai, sys, to_sdk_messages, user
 
 
 def test_construction1():
-    messages: List[BaseMessage] = [
+    messages: List[MessageABC] = [
         user("  human message1  "),
     ]
 
-    text, stop_sequences = cohere_emulator.display(messages)
+    text, stop_sequences = cohere_emulator.display(to_sdk_messages(messages))
 
     assert stop_sequences == ["\nUser:"]
     assert text == "human message1"
 
 
 def test_construction2():
-    messages = [
+    messages: List[MessageABC] = [
         sys(" system message1 "),
         user("  human message1  "),
         ai("     ai message1     "),
         user("  human message2  "),
     ]
 
-    text, stop_sequences = cohere_emulator.display(messages)
+    text, stop_sequences = cohere_emulator.display(to_sdk_messages(messages))
 
     assert stop_sequences == ["\nUser:"]
     assert text == "\n".join(

--- a/tests/unit_tests/chat_emulation/test_default_emulator.py
+++ b/tests/unit_tests/chat_emulation/test_default_emulator.py
@@ -5,8 +5,8 @@ from aidial_adapter_bedrock.llm.chat_emulator import (
     CueMapping,
     default_emulator,
 )
-from aidial_adapter_bedrock.llm.message import BaseMessage
-from tests.utils.messages import ai, sys, user
+from aidial_adapter_bedrock.llm.message import MessageABC
+from tests.utils.messages import ai, sys, to_sdk_messages, user
 
 noop_emulator = BasicChatEmulator(
     prelude_template=None,
@@ -19,14 +19,14 @@ noop_emulator = BasicChatEmulator(
 
 
 def test_construction():
-    messages = [
+    messages: List[MessageABC] = [
         sys(" system message1 "),
         user("  human message1  "),
         ai("     ai message1     "),
         user("  human message2  "),
     ]
 
-    text, stop_sequences = default_emulator.display(messages)
+    text, stop_sequences = default_emulator.display(to_sdk_messages(messages))
 
     prelude = default_emulator._prelude
     assert prelude is not None
@@ -44,16 +44,16 @@ def test_construction():
 
 
 def test_construction_with_single_user_message():
-    messages: List[BaseMessage] = [user(" human message ")]
-    text, stop_sequences = default_emulator.display(messages)
+    messages: List[MessageABC] = [user(" human message ")]
+    text, stop_sequences = default_emulator.display(to_sdk_messages(messages))
 
     assert stop_sequences == []
     assert text == " human message "
 
 
 def test_construction_with_single_ai_message():
-    messages: List[BaseMessage] = [ai(" ai message ")]
-    text, stop_sequences = default_emulator.display(messages)
+    messages: List[MessageABC] = [ai(" ai message ")]
+    text, stop_sequences = default_emulator.display(to_sdk_messages(messages))
 
     prelude = default_emulator._prelude
     assert prelude is not None
@@ -68,13 +68,13 @@ def test_construction_with_single_ai_message():
 
 
 def test_formatting():
-    messages = [
+    messages: List[MessageABC] = [
         sys("text1"),
         user("text2"),
         ai("text3"),
     ]
 
-    text, stop_sequences = noop_emulator.display(messages)
+    text, stop_sequences = noop_emulator.display(to_sdk_messages(messages))
 
     assert stop_sequences == []
     assert text == "text1text2text3"

--- a/tests/unit_tests/chat_emulation/test_default_emulator.py
+++ b/tests/unit_tests/chat_emulation/test_default_emulator.py
@@ -7,9 +7,9 @@ from tests.utils.messages import ai, sys, user
 
 noop_emulator = BasicChatEmulator(
     prelude_template=None,
-    add_cue=lambda *_: False,
-    add_invitation_cue=False,
-    fallback_to_completion=False,
+    should_prefix_with_cue=lambda *_: False,
+    should_add_invitation_cue=False,
+    should_fallback_to_completion=False,
     cues=CueMapping(system=None, human=None, ai=None),
     separator="",
 )

--- a/tests/unit_tests/chat_emulation/test_default_emulator.py
+++ b/tests/unit_tests/chat_emulation/test_default_emulator.py
@@ -23,7 +23,7 @@ def test_construction():
         user("  human message2  "),
     ]
 
-    text, stop_sequences = default_emulator.display((messages))
+    text, stop_sequences = default_emulator.display(messages)
 
     prelude = default_emulator._prelude
     assert prelude is not None
@@ -42,7 +42,7 @@ def test_construction():
 
 def test_construction_with_single_user_message():
     messages = [user(" human message ")]
-    text, stop_sequences = default_emulator.display((messages))
+    text, stop_sequences = default_emulator.display(messages)
 
     assert stop_sequences == []
     assert text == " human message "
@@ -50,7 +50,7 @@ def test_construction_with_single_user_message():
 
 def test_construction_with_single_ai_message():
     messages = [ai(" ai message ")]
-    text, stop_sequences = default_emulator.display((messages))
+    text, stop_sequences = default_emulator.display(messages)
 
     prelude = default_emulator._prelude
     assert prelude is not None
@@ -71,7 +71,7 @@ def test_formatting():
         ai("text3"),
     ]
 
-    text, stop_sequences = noop_emulator.display((messages))
+    text, stop_sequences = noop_emulator.display(messages)
 
     assert stop_sequences == []
     assert text == "text1text2text3"

--- a/tests/unit_tests/chat_emulation/test_default_emulator.py
+++ b/tests/unit_tests/chat_emulation/test_default_emulator.py
@@ -1,12 +1,9 @@
-from typing import List
-
 from aidial_adapter_bedrock.llm.chat_emulator import (
     BasicChatEmulator,
     CueMapping,
     default_emulator,
 )
-from aidial_adapter_bedrock.llm.message import MessageABC
-from tests.utils.messages import ai, sys, to_sdk_messages, user
+from tests.utils.messages import ai, sys, user
 
 noop_emulator = BasicChatEmulator(
     prelude_template=None,
@@ -19,14 +16,14 @@ noop_emulator = BasicChatEmulator(
 
 
 def test_construction():
-    messages: List[MessageABC] = [
+    messages = [
         sys(" system message1 "),
         user("  human message1  "),
         ai("     ai message1     "),
         user("  human message2  "),
     ]
 
-    text, stop_sequences = default_emulator.display(to_sdk_messages(messages))
+    text, stop_sequences = default_emulator.display((messages))
 
     prelude = default_emulator._prelude
     assert prelude is not None
@@ -44,16 +41,16 @@ def test_construction():
 
 
 def test_construction_with_single_user_message():
-    messages: List[MessageABC] = [user(" human message ")]
-    text, stop_sequences = default_emulator.display(to_sdk_messages(messages))
+    messages = [user(" human message ")]
+    text, stop_sequences = default_emulator.display((messages))
 
     assert stop_sequences == []
     assert text == " human message "
 
 
 def test_construction_with_single_ai_message():
-    messages: List[MessageABC] = [ai(" ai message ")]
-    text, stop_sequences = default_emulator.display(to_sdk_messages(messages))
+    messages = [ai(" ai message ")]
+    text, stop_sequences = default_emulator.display((messages))
 
     prelude = default_emulator._prelude
     assert prelude is not None
@@ -68,13 +65,13 @@ def test_construction_with_single_ai_message():
 
 
 def test_formatting():
-    messages: List[MessageABC] = [
+    messages = [
         sys("text1"),
         user("text2"),
         ai("text3"),
     ]
 
-    text, stop_sequences = noop_emulator.display(to_sdk_messages(messages))
+    text, stop_sequences = noop_emulator.display((messages))
 
     assert stop_sequences == []
     assert text == "text1text2text3"

--- a/tests/unit_tests/test_claude3_truncate_prompt.py
+++ b/tests/unit_tests/test_claude3_truncate_prompt.py
@@ -16,7 +16,7 @@ from aidial_adapter_bedrock.llm.model.claude.v3.adapter import (
 )
 from aidial_adapter_bedrock.llm.tools.tools_config import ToolsConfig
 from aidial_adapter_bedrock.llm.truncate_prompt import DiscardedMessages
-from tests.utils.messages import ai, sys, to_sdk_messages, user, user_with_image
+from tests.utils.messages import ai, sys, user, user_with_image
 
 _DEPLOYMENT = AdapterDeployment.supported(
     upstream=ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_OPUS
@@ -78,13 +78,11 @@ def mock_tokenize_text():
 
 
 async def test_one_turn_no_truncation(mock_tokenize_text):
-    messages = to_sdk_messages(
-        [
-            sys("11"),
-            user("22"),
-            ai("33"),
-        ]
-    )
+    messages = [
+        sys("11"),
+        user("22"),
+        ai("33"),
+    ]
 
     expected_tokens = (
         11 + (_PER_MESSAGE_TOKENS + 22) + (_PER_MESSAGE_TOKENS + 33)
@@ -100,12 +98,10 @@ async def test_one_turn_no_truncation(mock_tokenize_text):
 
 
 async def test_one_turn_with_image(mock_tokenize_text):
-    messages = to_sdk_messages(
-        [
-            sys("11"),
-            user_with_image("22", _PNG_IMAGE_50_50),
-        ]
-    )
+    messages = [
+        sys("11"),
+        user_with_image("22", _PNG_IMAGE_50_50),
+    ]
 
     expected_tokens = 11 + (_PER_MESSAGE_TOKENS + _PNG_IMAGE_50_50_TOKENS + 22)
 
@@ -124,13 +120,11 @@ async def test_one_turn_with_image(mock_tokenize_text):
 
 
 async def test_one_turn_with_tools(mock_tokenize_text):
-    messages = to_sdk_messages(
-        [
-            sys("11"),
-            user("22"),
-            ai("33"),
-        ]
-    )
+    messages = [
+        sys("11"),
+        user("22"),
+        ai("33"),
+    ]
 
     expected_tokens = (
         530 + 11 + 1 + (_PER_MESSAGE_TOKENS + 22) + (_PER_MESSAGE_TOKENS + 33)
@@ -149,13 +143,11 @@ async def test_one_turn_with_tools(mock_tokenize_text):
 
 
 async def test_one_turn_overflow(mock_tokenize_text):
-    messages = to_sdk_messages(
-        [
-            sys("11"),
-            user("22"),
-            ai("33"),
-        ]
-    )
+    messages = [
+        sys("11"),
+        user("22"),
+        ai("33"),
+    ]
 
     expected_tokens = (
         11 + (22 + _PER_MESSAGE_TOKENS) + (33 + _PER_MESSAGE_TOKENS)
@@ -170,13 +162,11 @@ async def test_one_turn_overflow(mock_tokenize_text):
 
 
 async def test_multiple_system_messages(mock_tokenize_text):
-    messages = to_sdk_messages(
-        [
-            sys("system1"),
-            sys("system2"),
-            user("user"),
-        ]
-    )
+    messages = [
+        sys("system1"),
+        sys("system2"),
+        user("user"),
+    ]
 
     with pytest.raises(ValidationError) as exc_info:
         await compute_discarded_messages(messages, 3)
@@ -187,14 +177,12 @@ async def test_multiple_system_messages(mock_tokenize_text):
 
 
 async def test_truncate_first_turn(mock_tokenize_text):
-    messages = to_sdk_messages(
-        [
-            user("11"),
-            ai("22"),
-            user("33"),
-            ai("44"),
-        ]
-    )
+    messages = [
+        user("11"),
+        ai("22"),
+        user("33"),
+        ai("44"),
+    ]
 
     expected_tokens = (
         (_PER_MESSAGE_TOKENS + 11)
@@ -213,15 +201,13 @@ async def test_truncate_first_turn(mock_tokenize_text):
 
 
 async def test_truncate_first_turn_with_system(mock_tokenize_text):
-    messages = to_sdk_messages(
-        [
-            sys("11"),
-            user("22"),
-            ai("33"),
-            user("44"),
-            ai("55"),
-        ]
-    )
+    messages = [
+        sys("11"),
+        user("22"),
+        ai("33"),
+        user("44"),
+        ai("55"),
+    ]
 
     discarded_messages = await compute_discarded_messages(
         messages, 11 + (_PER_MESSAGE_TOKENS + 44) + (_PER_MESSAGE_TOKENS + 55)
@@ -232,24 +218,22 @@ async def test_truncate_first_turn_with_system(mock_tokenize_text):
 
 async def test_truncate_first_turn_with_system_2(mock_tokenize_text):
     # Equivalent of test_truncate_first_turn_with_system with adjacent messages with the same role
-    messages = to_sdk_messages(
-        [
-            sys("11"),
-            # 22 block (discarded)
-            user("10"),
-            user("12"),
-            # 33 block (discarded)
-            ai("10"),
-            ai("11"),
-            ai("12"),
-            # 44 block
-            user("44"),
-            # 55 block
-            ai("12"),
-            ai("22"),
-            ai("21"),
-        ]
-    )
+    messages = [
+        sys("11"),
+        # 22 block (discarded)
+        user("10"),
+        user("12"),
+        # 33 block (discarded)
+        ai("10"),
+        ai("11"),
+        ai("12"),
+        # 44 block
+        user("44"),
+        # 55 block
+        ai("12"),
+        ai("22"),
+        ai("21"),
+    ]
 
     discarded_messages = await compute_discarded_messages(
         messages,
@@ -261,24 +245,22 @@ async def test_truncate_first_turn_with_system_2(mock_tokenize_text):
 
 async def test_truncate_first_turn_with_system_3(mock_tokenize_text):
     # Equivalent of test_truncate_first_turn_with_system_2 with one less tokens requests than the critical amount
-    messages = to_sdk_messages(
-        [
-            sys("11"),
-            # 22 block (discarded)
-            user("10"),
-            user("12"),
-            # 33 block (discarded)
-            ai("10"),
-            ai("11"),
-            ai("12"),
-            # 44 block
-            user("44"),
-            # 55 block
-            ai("12"),
-            ai("22"),
-            ai("21"),
-        ]
-    )
+    messages = [
+        sys("11"),
+        # 22 block (discarded)
+        user("10"),
+        user("12"),
+        # 33 block (discarded)
+        ai("10"),
+        ai("11"),
+        ai("12"),
+        # 44 block
+        user("44"),
+        # 55 block
+        ai("12"),
+        ai("22"),
+        ai("21"),
+    ]
 
     min_possible_tokens = (
         11 + (_PER_MESSAGE_TOKENS + 44) + (_PER_MESSAGE_TOKENS + 55)
@@ -296,12 +278,10 @@ async def test_truncate_first_turn_with_system_3(mock_tokenize_text):
 
 
 async def test_zero_turn_overflow(mock_tokenize_text):
-    messages = to_sdk_messages(
-        [
-            sys("11"),
-            user("22"),
-        ]
-    )
+    messages = [
+        sys("11"),
+        user("22"),
+    ]
 
     expected_tokens = 11 + (22 + _PER_MESSAGE_TOKENS)
 
@@ -314,14 +294,12 @@ async def test_zero_turn_overflow(mock_tokenize_text):
 
 
 async def test_chat_history_overflow(mock_tokenize_text):
-    messages = to_sdk_messages(
-        [
-            sys("11"),
-            user("22"),
-            ai("33"),
-            user("44"),
-        ]
-    )
+    messages = [
+        sys("11"),
+        user("22"),
+        ai("33"),
+        user("44"),
+    ]
 
     min_possible_tokens = 11 + (44 + _PER_MESSAGE_TOKENS)
 
@@ -335,16 +313,14 @@ async def test_chat_history_overflow(mock_tokenize_text):
 
 async def test_chat_history_overflow_2(mock_tokenize_text):
     # Equivalent of test_chat_history_overflow with adjacent messages with the same role
-    messages = to_sdk_messages(
-        [
-            sys("11"),
-            user("11"),
-            user("11"),
-            ai("11"),
-            ai("22"),
-            user("44"),
-        ]
-    )
+    messages = [
+        sys("11"),
+        user("11"),
+        user("11"),
+        ai("11"),
+        ai("22"),
+        user("44"),
+    ]
 
     min_possible_tokens = 11 + (44 + _PER_MESSAGE_TOKENS)
 

--- a/tests/unit_tests/test_truncate_prompt.py
+++ b/tests/unit_tests/test_truncate_prompt.py
@@ -1,5 +1,7 @@
 from typing import List, Optional
 
+from aidial_sdk.chat_completion import Message
+
 from aidial_adapter_bedrock.llm.chat_model import (
     keep_last_and_system_messages,
     trivial_partitioner,
@@ -11,16 +13,16 @@ from aidial_adapter_bedrock.llm.truncate_prompt import (
     _partition_indexer,
     compute_discarded_messages,
 )
-from tests.utils.messages import ai, sys, user
+from tests.utils.messages import ai, sys, to_sdk_messages, user
 
 
 async def truncate_prompt_by_words(
-    messages: List[BaseMessage],
+    messages: List[Message],
     user_limit: int,
     model_limit: Optional[int] = None,
 ) -> DiscardedMessages | TruncatePromptError:
-    async def _tokenize_by_words(messages: List[BaseMessage]) -> int:
-        return sum(len(msg.text_content.split()) for msg in messages)
+    async def _tokenize_by_words(messages: List[Message]) -> int:
+        return sum(len(msg.text().split()) for msg in messages)
 
     return await compute_discarded_messages(
         messages=messages,
@@ -138,7 +140,7 @@ async def test_inconsistent_limits():
     messages: List[BaseMessage] = [ai("text2")]
 
     truncation_error = await truncate_prompt_by_words(
-        messages=messages, user_limit=10, model_limit=5
+        messages=to_sdk_messages(messages), user_limit=10, model_limit=5
     )
 
     assert (

--- a/tests/unit_tests/test_truncate_prompt.py
+++ b/tests/unit_tests/test_truncate_prompt.py
@@ -6,14 +6,13 @@ from aidial_adapter_bedrock.llm.chat_model import (
     keep_last_and_system_messages,
     trivial_partitioner,
 )
-from aidial_adapter_bedrock.llm.message import BaseMessage
 from aidial_adapter_bedrock.llm.truncate_prompt import (
     DiscardedMessages,
     TruncatePromptError,
     _partition_indexer,
     compute_discarded_messages,
 )
-from tests.utils.messages import ai, sys, to_sdk_messages, user
+from tests.utils.messages import ai, sys, user
 
 
 async def truncate_prompt_by_words(
@@ -66,7 +65,6 @@ async def test_truncation():
         user("remove2"),
         user("query"),
     ]
-
     discarded_messages = await truncate_prompt_by_words(
         messages=messages, user_limit=3
     )
@@ -137,10 +135,10 @@ async def test_prompt_with_history_is_too_big():
 
 
 async def test_inconsistent_limits():
-    messages: List[BaseMessage] = [ai("text2")]
+    messages = [ai("text2")]
 
     truncation_error = await truncate_prompt_by_words(
-        messages=to_sdk_messages(messages), user_limit=10, model_limit=5
+        messages=messages, user_limit=10, model_limit=5
     )
 
     assert (

--- a/tests/utils/messages.py
+++ b/tests/utils/messages.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Sequence
 
 from aidial_sdk.chat_completion import Attachment, CustomContent
 from aidial_sdk.chat_completion import Message as DialMessage
@@ -30,5 +30,5 @@ def user_with_image(content: str, image_base64: str) -> HumanRegularMessage:
     return HumanRegularMessage(content=content, custom_content=custom_content)
 
 
-def to_sdk_messages(messages: List[MessageABC]) -> List[DialMessage]:
+def to_sdk_messages(messages: Sequence[MessageABC]) -> List[DialMessage]:
     return [msg.to_message() for msg in messages]

--- a/tests/utils/messages.py
+++ b/tests/utils/messages.py
@@ -1,34 +1,28 @@
-from typing import List, Sequence
-
-from aidial_sdk.chat_completion import Attachment, CustomContent
-from aidial_sdk.chat_completion import Message as DialMessage
+from aidial_sdk.chat_completion import Attachment, CustomContent, Message
 
 from aidial_adapter_bedrock.llm.message import (
     AIRegularMessage,
     HumanRegularMessage,
-    MessageABC,
     SystemMessage,
 )
 
 
-def sys(content: str) -> SystemMessage:
-    return SystemMessage(content=content)
+def sys(content: str) -> Message:
+    return SystemMessage(content=content).to_message()
 
 
-def ai(content: str) -> AIRegularMessage:
-    return AIRegularMessage(content=content)
+def ai(content: str) -> Message:
+    return AIRegularMessage(content=content).to_message()
 
 
-def user(content: str) -> HumanRegularMessage:
-    return HumanRegularMessage(content=content)
+def user(content: str) -> Message:
+    return HumanRegularMessage(content=content).to_message()
 
 
-def user_with_image(content: str, image_base64: str) -> HumanRegularMessage:
+def user_with_image(content: str, image_base64: str) -> Message:
     custom_content = CustomContent(
         attachments=[Attachment(type="image/png", data=image_base64)]
     )
-    return HumanRegularMessage(content=content, custom_content=custom_content)
-
-
-def to_sdk_messages(messages: Sequence[MessageABC]) -> List[DialMessage]:
-    return [msg.to_message() for msg in messages]
+    return HumanRegularMessage(
+        content=content, custom_content=custom_content
+    ).to_message()


### PR DESCRIPTION
Chat emulator migrated from `BaseMessage` to SDK `Message` to give way for a follow-up refactoring: https://github.com/epam/ai-dial-adapter-bedrock/pull/207

`BaseMessage` is introduced by the `ToolsEmulator`. It shouldn't leak to the `ChatEmulator`.