### PR TITLE
feat: support Cohere Command R/R+ models

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,4 @@
   ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "python.analysis.typeCheckingMode": "basic"
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Note that a model supports `/truncate_prompt` endpoint if and only if it support
 |AI21 Labs|Jurassic-2 Ultra v1|ai21.j2-ultra-v1|text-to-text|🟡|🟡|❌|❌|
 |AI21 Labs|Jurassic-2 Mid|ai21.j2-grande-instruct|text-to-text|🟡|🟡|❌|❌|
 |AI21 Labs|Jurassic-2 Mid v1|ai21.j2-mid-v1|text-to-text|🟡|🟡|❌|❌|
+|Cohere|Command R|cohere.command-r-v1:0|(text/document)-to-text|🟡|🟡|✅|❌|
+|Cohere|Command R+|cohere.command-r-plus-v1:0|(text/document)-to-text|🟡|🟡|✅|❌|
 |Cohere|Command|cohere.command-text-v14|text-to-text|🟡|🟡|❌|❌|
 |Cohere|Command Light|cohere.command-light-text-v14|text-to-text|🟡|🟡|❌|❌|
 

--- a/aidial_adapter_bedrock/deployments.py
+++ b/aidial_adapter_bedrock/deployments.py
@@ -51,6 +51,8 @@ class ChatCompletionDeployment(RegionInferenceDeployment):
 
     COHERE_COMMAND_TEXT_V14 = "cohere.command-text-v14"
     COHERE_COMMAND_LIGHT_TEXT_V14 = "cohere.command-light-text-v14"
+    COHERE_COMMAND_R_V1 = "cohere.command-r-v1:0"
+    COHERE_COMMAND_R_PLUS_V1 = "cohere.command-r-plus-v1:0"
 
     DEEPSEEK_R1_V2_US = "us.deepseek.r1-v1:0"
 

--- a/aidial_adapter_bedrock/llm/model/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/adapter.py
@@ -116,6 +116,14 @@ async def get_bedrock_adapter(
                 await Bedrock.acreate(aws_client_config), model
             )
         case (
+            ChatCompletionDeployment.COHERE_COMMAND_R_V1
+            | ChatCompletionDeployment.COHERE_COMMAND_R_PLUS_V1
+        ):
+            return await converse_adapter.create(
+                tools_support=ToolsSupport.ALWAYS,
+                supported_document_types=ConverseDocumentType.all(),
+            )
+        case (
             ChatCompletionDeployment.AMAZON_NOVA_MICRO
             | ChatCompletionDeployment.AMAZON_NOVA_PRO
             | ChatCompletionDeployment.AMAZON_NOVA_LITE

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -148,6 +148,8 @@ chat_deployments: Mapping[Deployment, str] = {
     ChatCompletionDeployment.META_LLAMA3_3_70B_INSTRUCT_V1: _EAST_2,
     ChatCompletionDeployment.COHERE_COMMAND_TEXT_V14: _WEST,
     ChatCompletionDeployment.COHERE_COMMAND_LIGHT_TEXT_V14: _WEST,
+    ChatCompletionDeployment.COHERE_COMMAND_R_V1: _WEST,
+    ChatCompletionDeployment.COHERE_COMMAND_R_PLUS_V1: _WEST,
     ChatCompletionDeployment.AMAZON_NOVA_MICRO: _EAST_1,
     ChatCompletionDeployment.AMAZON_NOVA_PRO: _EAST_1,
     ChatCompletionDeployment.AMAZON_NOVA_LITE: _EAST_1,
@@ -181,6 +183,8 @@ def supports_tools(deployment: ChatCompletionDeployment) -> bool:
         # tool support is claimed in the official documentation:
         # https://api-docs.deepseek.com/guides/function_calling
         # ChatCompletionDeployment.DEEPSEEK_R1_V2,
+        ChatCompletionDeployment.COHERE_COMMAND_R_V1,
+        ChatCompletionDeployment.COHERE_COMMAND_R_PLUS_V1,
     ]
 
 
@@ -222,6 +226,13 @@ def is_cohere(deployment: ChatCompletionDeployment) -> bool:
     return deployment in [
         ChatCompletionDeployment.COHERE_COMMAND_LIGHT_TEXT_V14,
         ChatCompletionDeployment.COHERE_COMMAND_TEXT_V14,
+    ]
+
+
+def is_cohere_command_plus(deployment: ChatCompletionDeployment) -> bool:
+    return deployment in [
+        ChatCompletionDeployment.COHERE_COMMAND_R_V1,
+        ChatCompletionDeployment.COHERE_COMMAND_R_PLUS_V1,
     ]
 
 
@@ -438,7 +449,7 @@ def get_test_cases(
                 status_code=400,
             )
         )
-    elif is_deepseek(origin):
+    elif is_deepseek(origin) or is_cohere_command_plus(origin):
         expected_whitespace_message = expected_empty_message = (
             ExpectedException(
                 type=BadRequestError,

--- a/tests/integration_tests/test_truncate_prompt.py
+++ b/tests/integration_tests/test_truncate_prompt.py
@@ -94,7 +94,7 @@ def get_test_cases(deployment: RegionDeployment) -> List[TestCase]:
             message=json.dumps(
                 {
                     "error": {
-                        "message": "Your request contained invalid structure on path inputs.0.messages.0.role. value is not a valid enumeration member; permitted: 'system', 'user', 'assistant', 'function', 'tool'",
+                        "message": "Your request contained invalid structure on path inputs.0.messages.0.role. value is not a valid enumeration member; permitted: 'system', 'developer', 'user', 'assistant', 'function', 'tool'",
                         "type": "invalid_request_error",
                         "code": "400",
                     }

--- a/tests/unit_tests/test_endpoints.py
+++ b/tests/unit_tests/test_endpoints.py
@@ -42,6 +42,8 @@ test_cases: List[Tuple[D, bool, bool, bool]] = [
     (D.META_LLAMA3_2_90B_INSTRUCT_V1, True, True, False),
     (D.COHERE_COMMAND_TEXT_V14, True, True, False),
     (D.COHERE_COMMAND_LIGHT_TEXT_V14, True, True, False),
+    (D.COHERE_COMMAND_R_V1, True, True, False),
+    (D.COHERE_COMMAND_R_PLUS_V1, True, True, False),
     (D.DEEPSEEK_R1_V2_US, True, True, False),
 ]
 


### PR DESCRIPTION
Under ids `cohere.command-r-v1:0` and `cohere.command-r-plus-v1:0` via the [Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html) adapter.