### PR TITLE
feat: support AI21 Jamba 1.5 Mini/Large models

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,8 @@ Note that a model supports `/truncate_prompt` endpoint if and only if it support
 |Amazon|Nova Pro|amazon.nova-pro-v1:0|(text/image/document)-to-text|🟡|🟡|✅|❌|
 |Amazon|Nova Lite|amazon.nova-lite-v1:0|(text/image/document)-to-text|🟡|🟡|✅|❌|
 |Amazon|Nova Micro|amazon.nova-micro-v1:0|text-to-text|🟡|🟡|❌|❌|
-|AI21 Labs|Jurassic-2 Ultra|ai21.j2-jumbo-instruct|text-to-text|🟡|🟡|❌|❌|
-|AI21 Labs|Jurassic-2 Ultra v1|ai21.j2-ultra-v1|text-to-text|🟡|🟡|❌|❌|
-|AI21 Labs|Jurassic-2 Mid|ai21.j2-grande-instruct|text-to-text|🟡|🟡|❌|❌|
-|AI21 Labs|Jurassic-2 Mid v1|ai21.j2-mid-v1|text-to-text|🟡|🟡|❌|❌|
+|AI21 Labs|Jamba 1.5 Large|ai21.jamba-1-5-large-v1:0|text-to-text|🟡|🟡|✅|❌|
+|AI21 Labs|Jamba 1.5 Mini|ai21.jamba-1-5-mini-v1:0|text-to-text|🟡|🟡|✅|❌|
 |Cohere|Command|cohere.command-text-v14|text-to-text|🟡|🟡|❌|❌|
 |Cohere|Command Light|cohere.command-light-text-v14|text-to-text|🟡|🟡|❌|❌|
 

--- a/aidial_adapter_bedrock/deployments.py
+++ b/aidial_adapter_bedrock/deployments.py
@@ -16,6 +16,8 @@ class ChatCompletionDeployment(RegionInferenceDeployment):
     AI21_J2_JUMBO_INSTRUCT = "ai21.j2-jumbo-instruct"
     AI21_J2_MID_V1 = "ai21.j2-mid-v1"
     AI21_J2_ULTRA_V1 = "ai21.j2-ultra-v1"
+    AI21_JAMBA_1_5_LARGE_V1 = "ai21.jamba-1-5-large-v1:0"
+    AI21_JAMBA_1_5_MINI_V1 = "ai21.jamba-1-5-mini-v1:0"
 
     ANTHROPIC_CLAUDE_INSTANT_V1 = "anthropic.claude-instant-v1"
     ANTHROPIC_CLAUDE_V2 = "anthropic.claude-v2"

--- a/aidial_adapter_bedrock/llm/model/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/adapter.py
@@ -87,6 +87,14 @@ async def get_bedrock_adapter(
                 await Bedrock.acreate(aws_client_config), model
             )
         case (
+            ChatCompletionDeployment.AI21_JAMBA_1_5_LARGE_V1
+            | ChatCompletionDeployment.AI21_JAMBA_1_5_MINI_V1
+        ):
+            return await converse_adapter.create(
+                tools_support=ToolsSupport.NON_STREAMING_ONLY,
+                supported_document_types=ConverseDocumentType.all(),
+            )
+        case (
             ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_XL
             | ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_XL_V1
         ):

--- a/aidial_adapter_bedrock/llm/model/llama/v3.py
+++ b/aidial_adapter_bedrock/llm/model/llama/v3.py
@@ -4,8 +4,9 @@ from aidial_adapter_bedrock.llm.converse.adapter import ConverseAdapter
 
 class ConverseAdapterWithStreamingEmulation(ConverseAdapter):
     """
-    Llama 3 models support tools only in the non-streaming mode.
+    Certain Converse API models support tools only in the non-streaming mode.
     So we need to run request in non-streaming mode, and then emulate streaming.
+    https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
     """
 
     def is_stream(self, params: ModelParameters) -> bool:

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -120,6 +120,8 @@ chat_deployments: Mapping[Deployment, str] = {
     ChatCompletionDeployment.AI21_J2_JUMBO_INSTRUCT: _EAST_1,
     ChatCompletionDeployment.AI21_J2_MID_V1: _EAST_1,
     ChatCompletionDeployment.AI21_J2_ULTRA_V1: _EAST_1,
+    ChatCompletionDeployment.AI21_JAMBA_1_5_LARGE_V1: _EAST_1,
+    ChatCompletionDeployment.AI21_JAMBA_1_5_MINI_V1: _EAST_1,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_INSTANT_V1: _WEST,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V2: _WEST,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V2_1: _WEST,
@@ -181,6 +183,9 @@ def supports_tools(deployment: ChatCompletionDeployment) -> bool:
         # tool support is claimed in the official documentation:
         # https://api-docs.deepseek.com/guides/function_calling
         # ChatCompletionDeployment.DEEPSEEK_R1_V2,
+        ChatCompletionDeployment.AI21_JAMBA_1_5_LARGE_V1,
+        # Mini is very bad with tools
+        # ChatCompletionDeployment.AI21_JAMBA_1_5_MINI_V1,
     ]
 
 
@@ -197,6 +202,8 @@ def supports_parallel_tool_calls(deployment: ChatCompletionDeployment) -> bool:
             ChatCompletionDeployment.META_LLAMA3_1_70B_INSTRUCT_V1,
             ChatCompletionDeployment.META_LLAMA3_1_405B_INSTRUCT_V1,
             ChatCompletionDeployment.META_LLAMA3_3_70B_INSTRUCT_V1,
+            ChatCompletionDeployment.AI21_JAMBA_1_5_LARGE_V1,
+            ChatCompletionDeployment.AI21_JAMBA_1_5_MINI_V1,
         ]
         and not is_nova(deployment)
         and supports_tools(deployment)
@@ -261,6 +268,8 @@ def is_ai21(deployment: ChatCompletionDeployment) -> bool:
     return deployment in [
         ChatCompletionDeployment.AI21_J2_GRANDE_INSTRUCT,
         ChatCompletionDeployment.AI21_J2_JUMBO_INSTRUCT,
+        ChatCompletionDeployment.AI21_JAMBA_1_5_MINI_V1,
+        ChatCompletionDeployment.AI21_JAMBA_1_5_LARGE_V1,
     ]
 
 
@@ -438,7 +447,7 @@ def get_test_cases(
                 status_code=400,
             )
         )
-    elif is_deepseek(origin):
+    elif is_deepseek(origin) or is_ai21(origin):
         expected_whitespace_message = expected_empty_message = (
             ExpectedException(
                 type=BadRequestError,
@@ -487,15 +496,9 @@ def get_test_cases(
         and s.finish_reasons == ["length"],
     )
 
-    # ai21 models do not support more than one stop word
-    if is_ai21(origin):
-        stop = ["John"]
-    else:
-        stop = ["John", "john"]
-
     test_case(
         name="stop sequence",
-        stop=stop,
+        stop=["John", "john"],
         messages=[user('Reply with "John"')],
         expected=lambda s: "John" not in s.content.lower(),
     )

--- a/tests/integration_tests/test_truncate_prompt.py
+++ b/tests/integration_tests/test_truncate_prompt.py
@@ -94,7 +94,7 @@ def get_test_cases(deployment: RegionDeployment) -> List[TestCase]:
             message=json.dumps(
                 {
                     "error": {
-                        "message": "Your request contained invalid structure on path inputs.0.messages.0.role. value is not a valid enumeration member; permitted: 'system', 'user', 'assistant', 'function', 'tool'",
+                        "message": "Your request contained invalid structure on path inputs.0.messages.0.role. value is not a valid enumeration member; permitted: 'system', 'developer', 'user', 'assistant', 'function', 'tool'",
                         "type": "invalid_request_error",
                         "code": "400",
                     }

--- a/tests/unit_tests/test_endpoints.py
+++ b/tests/unit_tests/test_endpoints.py
@@ -15,6 +15,8 @@ test_cases: List[Tuple[D, bool, bool, bool]] = [
     (D.AI21_J2_JUMBO_INSTRUCT, True, True, False),
     (D.AI21_J2_MID_V1, True, True, False),
     (D.AI21_J2_ULTRA_V1, True, True, False),
+    (D.AI21_JAMBA_1_5_LARGE_V1, True, True, False),
+    (D.AI21_JAMBA_1_5_MINI_V1, True, True, False),
     (D.ANTHROPIC_CLAUDE_INSTANT_V1, True, True, False),
     (D.ANTHROPIC_CLAUDE_V2, True, True, False),
     (D.ANTHROPIC_CLAUDE_V2_1, True, True, False),


### PR DESCRIPTION
Under ids `ai21.jamba-1-5-large-v1:0` and `ai21.jamba-1-5-mini-v1:0` via the [Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html) adapter.