### PR TITLE
feat: support Stable Diffusion 3.5 Large model

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Note that a model supports `/truncate_prompt` endpoint if and only if it support
 |Meta|Llama 3 Chat 8B Instruct|meta.llama3-8b-instruct-v1:0|text-to-text|🟡|🟡|❌|❌|
 |Stability AI|SDXL 1.0|stability.stable-diffusion-xl-v1|text-to-image|❌|🟡|❌|❌|
 |Stability AI|SD3 Large 1.0|stability.sd3-large-v1:0|(text/image)-to-image|❌|🟡|❌|✅|
+|Stability AI|Stable Diffusion 3.5 Large|stability.sd3-5-large-v1:0|(text/image)-to-image|❌|🟡|❌|✅|
 |Stability AI|Stable Image Ultra 1.0|stability.stable-image-ultra-v1:0|text-to-image|❌|🟡|❌|✅|
 |Stability AI|Stable Image Core 1.0|stability.stable-image-core-v1:0|text-to-image|❌|🟡|❌|✅|
 |Amazon|Titan Text G1 - Express|amazon.titan-tg1-large|text-to-text|🟡|🟡|❌|❌|

--- a/aidial_adapter_bedrock/deployments.py
+++ b/aidial_adapter_bedrock/deployments.py
@@ -36,6 +36,7 @@ class ChatCompletionDeployment(RegionInferenceDeployment):
 
     STABILITY_STABLE_IMAGE_CORE_V1 = "stability.stable-image-core-v1:0"
     STABILITY_STABLE_DIFFUSION_3_LARGE_V1 = "stability.sd3-large-v1:0"
+    STABILITY_STABLE_DIFFUSION_3_5_LARGE_V1 = "stability.sd3-5-large-v1:0"
     STABILITY_STABLE_IMAGE_ULTRA_V1 = "stability.stable-image-ultra-v1:0"
 
     META_LLAMA3_8B_INSTRUCT_V1 = "meta.llama3-8b-instruct-v1:0"

--- a/aidial_adapter_bedrock/llm/model/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/adapter.py
@@ -97,6 +97,7 @@ async def get_bedrock_adapter(
             ChatCompletionDeployment.STABILITY_STABLE_IMAGE_CORE_V1
             | ChatCompletionDeployment.STABILITY_STABLE_IMAGE_ULTRA_V1
             | ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_LARGE_V1
+            | ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_5_LARGE_V1
         ):
             adapter = StabilityV2Adapter.create(
                 await Bedrock.acreate(aws_client_config),

--- a/aidial_adapter_bedrock/llm/model/stability/v2.py
+++ b/aidial_adapter_bedrock/llm/model/stability/v2.py
@@ -111,6 +111,7 @@ Stability_V2_V3 = Literal[
     ChatCompletionDeployment.STABILITY_STABLE_IMAGE_CORE_V1,
     ChatCompletionDeployment.STABILITY_STABLE_IMAGE_ULTRA_V1,
     ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_LARGE_V1,
+    ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_5_LARGE_V1,
 ]
 
 
@@ -158,7 +159,10 @@ def _get_spec(deployment: Stability_V2_V3) -> Spec:
                 height_constraints=None,
                 configuration_cls=StabilityImageConfiguration,
             )
-        case ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_LARGE_V1:
+        case (
+            ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_LARGE_V1
+            | ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_5_LARGE_V1
+        ):
             return Spec(
                 image_to_image_supported=True,
                 width_constraints=(640, 1536),

--- a/tests/integration_tests/test_stable_diffusion.py
+++ b/tests/integration_tests/test_stable_diffusion.py
@@ -29,10 +29,8 @@ TEXT_TO_IMAGE_ONLY_MODELS = [
 ]
 
 IMAGE_TO_IMAGE_SUPPORTED_MODELS = [
-    (
-        ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_LARGE_V1,
-        _WEST,
-    ),
+    (ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_LARGE_V1, _WEST),
+    (ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_5_LARGE_V1, _WEST),
 ]
 VISION_MODEL = ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_5_SONNET.US
 

--- a/tests/unit_tests/test_endpoints.py
+++ b/tests/unit_tests/test_endpoints.py
@@ -28,6 +28,7 @@ test_cases: List[Tuple[D, bool, bool, bool]] = [
     (D.STABILITY_STABLE_DIFFUSION_XL, False, True, False),
     (D.STABILITY_STABLE_DIFFUSION_XL_V1, False, True, False),
     (D.STABILITY_STABLE_DIFFUSION_3_LARGE_V1, False, True, True),
+    (D.STABILITY_STABLE_DIFFUSION_3_5_LARGE_V1, False, True, True),
     (D.STABILITY_STABLE_IMAGE_ULTRA_V1, False, True, True),
     (D.STABILITY_STABLE_IMAGE_CORE_V1, False, True, True),
     (D.META_LLAMA3_8B_INSTRUCT_V1, True, True, False),


### PR DESCRIPTION
... via `stability.sd3-5-large-v1:0` deployment id