### PR TITLE
fix: Claude: work around Anthropic SDK fail when `stream=False` & `max_tokens>128K/6`

### DIFF
--- a/aidial_adapter_bedrock/aws_client_config.py
+++ b/aidial_adapter_bedrock/aws_client_config.py
@@ -1,6 +1,9 @@
 import os
+from functools import cache
 
+import anthropic
 import boto3
+import httpx
 from aidial_sdk.embeddings import Request
 from pydantic import BaseModel, Field
 
@@ -13,6 +16,18 @@ class AWSClientCredentials(BaseModel):
     aws_access_key_id: str
     aws_secret_access_key: str
     aws_session_token: str | None = None
+
+
+@cache
+def get_default_anthropic_timeout() -> httpx.Timeout:
+    # Providing a timeout marginally different from the default Anthropic timeout
+    # in order to disable the check that throws an error when
+    # stream=False & max_tokens>=128K/6:
+    # https://github.com/anthropics/anthropic-sdk-python/blob/f5bdf5137cc3da4d3663aedb8c63d54652981c3b/src/anthropic/resources/beta/messages/messages.py#L2175-L2176
+
+    timeout = anthropic._constants.DEFAULT_TIMEOUT.as_dict()
+    timeout["connect"] *= 1.0001  # type: ignore
+    return httpx.Timeout(**timeout)
 
 
 class AWSClientConfig(BaseModel):
@@ -28,7 +43,7 @@ class AWSClientConfig(BaseModel):
         return client_kwargs
 
     def get_anthropic_bedrock_client_kwargs(self) -> dict:
-        client_kwargs = {"aws_region": self.region}
+        client_kwargs: dict = {"aws_region": self.region}
 
         if self.credentials:
             credentials = remove_nones(
@@ -39,6 +54,8 @@ class AWSClientConfig(BaseModel):
                 }
             )
             client_kwargs.update(credentials)
+
+        client_kwargs["timeout"] = get_default_anthropic_timeout()
         return client_kwargs
 
 


### PR DESCRIPTION
`anthropic>=0.47.0` has a check that fails for requests with `stream=False` and `max_tokens>128K/6` and when no timeout is specified in the Antropic client:

1. Checking the `stream` parameter and default timeout:

https://github.com/anthropics/anthropic-sdk-python/commit/b363339ff0a0d416c05ce5ed058f201fa4fcc69f#diff-ab95ecc45ef24792696531eca2ddfa9dc8602fc09ed5724c962aad0b9790e992R2177-R2178

2. Checking the `max_tokens` parameter:

https://github.com/anthropics/anthropic-sdk-python/commit/b363339ff0a0d416c05ce5ed058f201fa4fcc69f#diff-3acba71f89118b06b03f2ba9f782c49ceed5bb9f68d62727d929f1841b61d12bR668-R681

To avoid the fail, the adapter provides a timeout marginally different from the default one:

```python
def get_default_anthropic_timeout() -> httpx.Timeout:
    timeout = anthropic._constants.DEFAULT_TIMEOUT.as_dict()
    timeout["connect"] *= 1.0001
    return httpx.Timeout(**timeout)
```