### PR TITLE
fix: Claude: tentatively support `tool_choice=none`

### DIFF
--- a/aidial_adapter_bedrock/llm/converse/input.py
+++ b/aidial_adapter_bedrock/llm/converse/input.py
@@ -13,6 +13,7 @@ from aidial_sdk.chat_completion import (
 from aidial_sdk.chat_completion import Role as DialRole
 from aidial_sdk.chat_completion import Tool as DialTool
 from aidial_sdk.chat_completion import ToolCall as DialToolCall
+from aidial_sdk.chat_completion import ToolChoice as DialToolChoice
 from aidial_sdk.chat_completion.request import MessageContentRefusalPart
 from aidial_sdk.exceptions import RuntimeServerError
 
@@ -91,15 +92,19 @@ def to_converse_tools(tools_config: ToolsConfig) -> ConverseTools:
         if cache_point_part := _get_cache_point_part(tool):
             tools.append(cache_point_part)
 
-    match (tools_config.required, tools_config.tools):
-        case (True, [tool]):
-            tool_choice = {"tool": {"name": tool.function.name}}
-        case (True, _):
+    match tools_config.tool_choice:
+        case DialToolChoice(function=function):
+            tool_choice = {"tool": {"name": function.name}}
+        case "required":
             tool_choice = {"any": {}}
-        case (False, _):
+        case "auto":
             tool_choice = {"auto": {}}
+        case "none":
+            raise ValidationError(
+                "tool_choice=none isn't supported by Converse API"
+            )
         case _:
-            assert_never(tools_config)
+            assert_never(tools_config.tool_choice)
 
     return {"tools": tools, "toolChoice": tool_choice}
 

--- a/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
@@ -3,6 +3,7 @@ from logging import DEBUG
 from typing import List, Literal, Optional, Tuple, Type, assert_never
 
 from aidial_sdk.chat_completion import Message as DialMessage
+from aidial_sdk.chat_completion import ToolChoice as DialToolChoice
 from anthropic import NOT_GIVEN, AsyncAnthropic, AsyncAnthropicBedrock, NotGiven
 from anthropic._resource import AsyncAPIResource
 from anthropic.lib.streaming import (
@@ -42,6 +43,7 @@ from anthropic.types.beta import BetaThinkingBlock as ThinkingBlock
 from anthropic.types.beta import BetaThinkingConfigParam as ThinkingConfigParam
 from anthropic.types.beta import BetaToolChoiceAnyParam as ToolChoiceAnyParam
 from anthropic.types.beta import BetaToolChoiceAutoParam as ToolChoiceAutoParam
+from anthropic.types.beta import BetaToolChoiceNoneParam as ToolChoiceNoneParam
 from anthropic.types.beta import BetaToolChoiceParam as ToolChoice
 from anthropic.types.beta import BetaToolChoiceToolParam as ToolChoiceToolParam
 from anthropic.types.beta import BetaToolUseBlock as ToolUseBlock
@@ -200,17 +202,19 @@ class Adapter(ChatCompletionAdapter):
         if (tool_config := params.tool_config) is not None:
             tools = [to_claude_tool_config(tool) for tool in tool_config.tools]
 
-            match (tool_config.required, tool_config.tools):
-                case (True, [tool]):
+            match tool_config.tool_choice:
+                case DialToolChoice(function=function):
                     tool_choice = ToolChoiceToolParam(
-                        type="tool", name=tool.function.name
+                        type="tool", name=function.name
                     )
-                case (True, _):
+                case "required":
                     tool_choice = ToolChoiceAnyParam(type="any")
-                case (False, _):
+                case "auto":
                     tool_choice = ToolChoiceAutoParam(type="auto")
+                case "none":
+                    tool_choice = ToolChoiceNoneParam(type="none")
                 case _:
-                    assert_never(tool_config)
+                    assert_never(tool_config.tool_choice)
 
             # NOTE tool_choice.disable_parallel_tool_use=True option isn't supported
             # by older Claude3 versions, so we limit the number of generated function calls

--- a/aidial_adapter_bedrock/llm/model/claude/v3/converters.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/converters.py
@@ -33,7 +33,9 @@ from anthropic.types.beta import (
 )
 from anthropic.types.beta import BetaToolUseBlockParam as ToolUseBlockParam
 from anthropic.types.beta import BetaUsage as Usage
-from anthropic.types.beta.beta_image_block_param import Source
+from anthropic.types.beta.beta_base64_image_source_param import (
+    BetaBase64ImageSourceParam as Base64ImageSourceParam,
+)
 from pydantic import BaseModel
 from pydantic import ValidationError as PydValidationError
 
@@ -111,7 +113,7 @@ def _create_text_block(text: str) -> TextBlockParam:
 
 def _create_image_block(resource: Resource) -> ImageBlockParam:
     return ImageBlockParam(
-        source=Source(
+        source=Base64ImageSourceParam(
             data=resource.data_base64,
             media_type=cast(ImageMediaType, resource.type),
             type="base64",

--- a/aidial_adapter_bedrock/llm/model/claude/v3/tokenizer.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/tokenizer.py
@@ -99,8 +99,14 @@ def _get_image_size(image_data: Union[str, Base64FileInput]) -> Tuple[int, int]:
 
 
 def _tokenize_image(source: Source) -> int:
-    width, height = _get_image_size(source["data"])
-    return math.ceil((width * height) / 750.0)
+    match source["type"]:
+        case "url":
+            return 0
+        case "base64":
+            width, height = _get_image_size(source["data"])
+            return math.ceil((width * height) / 750.0)
+        case _:
+            assert_never(source)
 
 
 def _tokenize_tool_use(id: str, input: object, name: str) -> int:
@@ -197,7 +203,7 @@ def _tokenize_tool_param(tool: ToolParam) -> int:
 
 def _tokenize_tool_system_message(
     deployment: Claude3Deployment,
-    tool_choice: Literal["auto", "any", "tool"],
+    tool_choice: Literal["none", "auto", "any", "tool"],
 ) -> int:
     match deployment:
         case ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_5_SONNET:

--- a/aidial_adapter_bedrock/llm/tools/claude_protocol.py
+++ b/aidial_adapter_bedrock/llm/tools/claude_protocol.py
@@ -156,7 +156,7 @@ def _parse_function_call(text: str) -> FunctionCall:
         tool_name = invocation["tool_name"]
         parameters = invocation["parameters"]
     except Exception:
-        raise Exception(f"Unable to parse function call: {text!r}")
+        raise Exception("Unable to parse function call")
 
     return FunctionCall(name=tool_name, arguments=json.dumps(parameters))
 

--- a/aidial_adapter_bedrock/llm/tools/claude_protocol.py
+++ b/aidial_adapter_bedrock/llm/tools/claude_protocol.py
@@ -156,7 +156,7 @@ def _parse_function_call(text: str) -> FunctionCall:
         tool_name = invocation["tool_name"]
         parameters = invocation["parameters"]
     except Exception:
-        raise Exception("Unable to parse function call")
+        raise Exception(f"Unable to parse function call: {text!r}")
 
     return FunctionCall(name=tool_name, arguments=json.dumps(parameters))
 

--- a/aidial_adapter_bedrock/llm/tools/tools_config.py
+++ b/aidial_adapter_bedrock/llm/tools/tools_config.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Literal, Self, Tuple, assert_never
+from typing import Dict, List, Literal, Self
 
 from aidial_sdk.chat_completion import (
     Function,
@@ -32,12 +32,7 @@ class ToolsConfig(BaseModel):
     List of functions/tools.
     """
 
-    required: bool
-    """
-    True forces the model to call one of the available functions.
-    False allows the model to pick between generating a message or
-    calling one or more tools/functions.
-    """
+    tool_choice: Literal["auto", "none", "required"] | ToolChoice
 
     tool_ids: Dict[str, str] | None
     """
@@ -81,30 +76,6 @@ class ToolsConfig(BaseModel):
         return tool_name
 
     @staticmethod
-    def filter_tools(
-        tool_choice: Literal["auto", "none", "required"] | ToolChoice,
-        tools: List[Tool],
-    ) -> Tuple[bool, List[Tool]]:
-        match tool_choice:
-            case "none":
-                return False, []
-            case "auto":
-                return False, tools
-            case "required":
-                return True, tools
-            case ToolChoice(function=FunctionChoice(name=name)):
-                new_tools = [
-                    tool for tool in tools if tool.function.name == name
-                ]
-                if not new_tools:
-                    raise ValidationError(
-                        f"Tool {name!r} is not on the list of available tools"
-                    )
-                return True, new_tools
-            case _:
-                assert_never(tool_choice)
-
-    @staticmethod
     def _function_call_to_tool_choice(
         function_call: Literal["auto", "none"] | FunctionChoice | None,
     ) -> Literal["auto", "none", "required"] | ToolChoice | None:
@@ -132,33 +103,25 @@ class ToolsConfig(BaseModel):
                 ToolsConfig._get_tool_from_function(tool)
                 for tool in request.functions
             ]
-            tool_call = ToolsConfig._function_call_to_tool_choice(
+            tool_choice = ToolsConfig._function_call_to_tool_choice(
                 request.function_call
             )
             tool_ids = None
-
         elif request.tools is not None:
             tools = [
                 ToolsConfig._get_tool_from_function(tool)
                 for tool in request.tools
             ]
-            tool_call = request.tool_choice
+            tool_choice = request.tool_choice
             tool_ids = _collect_tool_ids(request.messages)
-
         else:
-            tools = []
-            tool_call = None
-            tool_ids = None
-
-        if tool_call is None:
-            tool_call = "auto" if tools else "none"
-
-        required, selected = ToolsConfig.filter_tools(tool_call, tools)
-
-        if selected == []:
             return None
 
-        return cls(tools=selected, required=required, tool_ids=tool_ids)
+        return cls(
+            tools=tools,
+            tool_choice=tool_choice or "auto",
+            tool_ids=tool_ids,
+        )
 
 
 def validate_messages(request: AzureChatCompletionRequest) -> None:

--- a/aidial_adapter_bedrock/server/exceptions.py
+++ b/aidial_adapter_bedrock/server/exceptions.py
@@ -62,13 +62,14 @@ def _parse_anthropic_streaming_error(text: str) -> DialException | None:
         return None
     text = text.removeprefix(prefix)
 
-    code_pattern = re.search(r"['\"]status_code['\"]:\s*(\d+)", text)
-    message_pattern = re.search(r"['\"]message['\"]:\s*['\"](.*?)['\"]", text)
+    code_pattern = re.search(r"'status_code':\s*(\d+)", text)
+    message_pattern = re.search(r"\"message\":\s*\"(.*?)\"", text)
 
     code = int(code_pattern.group(1)) if code_pattern else None
     message = str(message_pattern.group(1)) if message_pattern else None
 
     if code and message:
+        message = message.replace("\\'", "'")
         return _create_error(code, message)
     return None
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -201,13 +201,13 @@ pluggy = ">=0.4.0"
 
 [[package]]
 name = "anthropic"
-version = "0.47.2"
+version = "0.49.0"
 description = "The official Python library for the anthropic API"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "anthropic-0.47.2-py3-none-any.whl", hash = "sha256:61b712a56308fce69f04d92ba0230ab2bc187b5bce17811d400843a8976bb67f"},
-    {file = "anthropic-0.47.2.tar.gz", hash = "sha256:452f4ca0c56ffab8b6ce9928bf8470650f88106a7001b250895eb65c54cfa44c"},
+    {file = "anthropic-0.49.0-py3-none-any.whl", hash = "sha256:bbc17ad4e7094988d2fa86b87753ded8dce12498f4b85fe5810f208f454a8375"},
+    {file = "anthropic-0.49.0.tar.gz", hash = "sha256:c09e885b0f674b9119b4f296d8508907f6cff0009bc20d5cf6b35936c40b4398"},
 ]
 
 [package.dependencies]
@@ -2839,4 +2839,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11,<4.0"
-content-hash = "a56146b9c8a7855bc63e5d62a53a9eaf23769aca539accf9e6a6749c67e026bf"
+content-hash = "dea4371ef75c4a9bd3090a56e533e8ac2fe0be82f78eaefa05e72c98ff779f1d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ python = "^3.11,<4.0"
 boto3 = "1.37.24"
 botocore = "1.37.24"
 aidial-sdk = { version = "0.21.0", extras = ["telemetry"] }
-anthropic = { version = "0.47.2", extras = ["bedrock"] }
+anthropic = { version = "0.49.0", extras = ["bedrock"] }
 # Only for the tokenizer for Claude v1/v2 models
 anthropic_bedrock = "0.8.0"
 fastapi = "0.115.2"

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -545,9 +545,53 @@ def get_test_cases(
     )
 
     if supports_tools(origin):
+        if "claude-3-7" in origin.value:
+            tool_choice_none_error = ExpectedException(
+                type=BadRequestError,
+                message="tool_choice: Input tag 'none' found using 'type' does not match any of the expected tags",
+                status_code=400,
+            )
+        elif "claude-3" in origin.value:
+            tool_choice_none_error = ExpectedException(
+                type=BadRequestError,
+                message="none is not a valid enum value, please reformat your input and try again",
+                status_code=400,
+            )
+        elif "claude-v2" in origin.value:
+            tool_choice_none_error = None
+        else:
+            tool_choice_none_error = ExpectedException(
+                type=UnprocessableEntityError,
+                message="tool_choice=none isn't supported by Converse API",
+                status_code=422,
+            )
+
+        if tool_choice_none_error:
+            test_case(
+                name="tool_choice=none + existing tool calls",
+                messages=[
+                    user("What's the weather in Glasgow?"),
+                    ai_tools(
+                        [
+                            tool_request(
+                                "tool_1",
+                                "get_weather",
+                                {"location": "Glasgow", "unit": "celsius"},
+                            )
+                        ]
+                    ),
+                    tool_response("tool_1", "20 degrees"),
+                    ai("It's 20 degrees"),
+                    user("2+2=?"),
+                ],
+                tools=[function_to_tool(GET_WEATHER_FUNCTION)],
+                tool_choice="none",
+                expected=tool_choice_none_error,
+            )
+
         if supports_forced_tool_choice(origin):
             test_case(
-                name="forced tool call",
+                name="tool_choice=function",
                 messages=[user("Glasgow is a city in Scotland. What's 2+2?")],
                 tools=[function_to_tool(GET_WEATHER_FUNCTION)],
                 tool_choice={

--- a/tests/unit_tests/converse/test_converse_adapter.py
+++ b/tests/unit_tests/converse/test_converse_adapter.py
@@ -443,7 +443,7 @@ TEST_CASES = [
                         custom_fields=DIAL_TOOL_CACHE_POINT,
                     )
                 ],
-                required=True,
+                tool_choice="required",
                 tool_ids=None,
             )
         ),
@@ -523,7 +523,7 @@ TEST_CASES = [
                         function=DIAL_WEATHER_FUNCTION,
                     )
                 ],
-                required=True,
+                tool_choice="required",
                 tool_ids=None,
             )
         ),

--- a/tests/unit_tests/converse/test_converse_adapter.py
+++ b/tests/unit_tests/converse/test_converse_adapter.py
@@ -8,6 +8,7 @@ from aidial_sdk.chat_completion.request import (
     CustomContent,
     Function,
     FunctionCall,
+    FunctionChoice,
     ImageURL,
     Message,
     MessageContentImagePart,
@@ -16,6 +17,7 @@ from aidial_sdk.chat_completion.request import (
     Role,
     Tool,
     ToolCall,
+    ToolChoice,
     ToolCustomFields,
 )
 
@@ -453,7 +455,7 @@ TEST_CASES = [
                     CONVERSE_WEATHER_TOOL_SPEC,
                     CONVERSE_CACHE_POINT_PART,
                 ],
-                "toolChoice": {"tool": {"name": "get_weather"}},
+                "toolChoice": {"any": {}},
             },
             messages=ListProjection(
                 list=[
@@ -523,7 +525,9 @@ TEST_CASES = [
                         function=DIAL_WEATHER_FUNCTION,
                     )
                 ],
-                tool_choice="required",
+                tool_choice=ToolChoice(
+                    type="function", function=FunctionChoice(name="get_weather")
+                ),
                 tool_ids=None,
             )
         ),

--- a/tests/unit_tests/test_claude3_truncate_prompt.py
+++ b/tests/unit_tests/test_claude3_truncate_prompt.py
@@ -51,7 +51,7 @@ async def compute_discarded_messages(
 
 _TOOL_CONFIG = ToolsConfig(
     tools=[Tool(type="function", function=Function(name="function"))],
-    required=False,
+    tool_choice="auto",
     tool_ids={},
 )
 

--- a/tests/utils/openai.py
+++ b/tests/utils/openai.py
@@ -236,9 +236,9 @@ async def chat_completion(
             temperature=temperature,
             n=n,
             function_call="auto" if functions is not None else NOT_GIVEN,
-            functions=functions or NOT_GIVEN,
-            tools=tools or NOT_GIVEN,
+            functions=NOT_GIVEN if functions is None else functions,
             tool_choice=tool_choice or NOT_GIVEN,
+            tools=NOT_GIVEN if tools is None else tools,
             extra_body=extra_body,
         )
 


### PR DESCRIPTION
Resolves #273 

Claude from Anthropic **Bedrock** doesn't support `tool_choice=none`: https://github.com/boto/botocore/issues/3458

However, it will likely one day, since Claude accessed via API-key does support it.
Added a few negative tests.

Also **removed filtration of tools** for `tool_choice=none` or `tool_choice=FunctionChoice` because it 
1. hides available tools from a model, so the request like `Show me the tools you have access to` doesn't make sense,
2. obscures the meaning of tool calls/responses referencing a tool whose definition was removed.