### PR TITLE
fix: TTL cache datetime comparison

### DIFF
--- a/aidial_adapter_bedrock/utils/cache.py
+++ b/aidial_adapter_bedrock/utils/cache.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Coroutine, ParamSpec, Tuple, TypeVar
 
 from pydantic import BaseModel
 
+from aidial_adapter_bedrock.utils.datetime import ensure_utc, now_utc
 from aidial_adapter_bedrock.utils.log_config import app_logger as log
 
 _P = ParamSpec("_P")
@@ -28,12 +29,13 @@ def ttl_cache(
             if value is not None:
                 if expiry is None:
                     return value
-                elif expiry > datetime.now() + timedelta(minutes=1):
+                elif expiry > now_utc() + timedelta(minutes=1):
                     return value
                 else:
                     log.debug("cache entry has expired")
 
             (expiration, value) = await func(*args, **kwargs)
+            expiration = None if expiration is None else ensure_utc(expiration)
             _cache[key] = (expiration, value)
             return value
 

--- a/aidial_adapter_bedrock/utils/cache.py
+++ b/aidial_adapter_bedrock/utils/cache.py
@@ -29,13 +29,12 @@ def ttl_cache(
             if value is not None:
                 if expiry is None:
                     return value
-                elif expiry > now_utc() + timedelta(minutes=1):
+                elif ensure_utc(expiry) > now_utc() + timedelta(minutes=1):
                     return value
                 else:
                     log.debug("cache entry has expired")
 
             (expiration, value) = await func(*args, **kwargs)
-            expiration = None if expiration is None else ensure_utc(expiration)
             _cache[key] = (expiration, value)
             return value
 

--- a/aidial_adapter_bedrock/utils/datetime.py
+++ b/aidial_adapter_bedrock/utils/datetime.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timezone
+
+_default_tz = timezone.utc
+
+
+def now_utc() -> datetime:
+    return datetime.now(_default_tz)
+
+
+def ensure_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=_default_tz)
+    else:
+        return dt.astimezone(_default_tz)

--- a/tests/unit_tests/test_cache.py
+++ b/tests/unit_tests/test_cache.py
@@ -1,7 +1,7 @@
 import asyncio
 import sys
 from datetime import datetime as original_datetime
-from datetime import timedelta
+from datetime import timedelta, timezone
 
 import pytest
 from pydantic import BaseModel
@@ -12,23 +12,41 @@ from aidial_adapter_bedrock.utils.cache import _make_key, ttl_cache
 class datetime(original_datetime):
     @classmethod
     def now(cls, tz=None):  # type: ignore
-        return original_datetime(2025, 5, 20, 12, 0, 0)
+        return original_datetime(2025, 1, 1, 0, 0, 0, tzinfo=tz)
+
+
+@pytest.fixture(
+    params=[None, timezone.utc],
+    ids=["offset-naive", "offset-aware-utc"],
+)
+def time_zone(request):
+    return request.param
+
+
+@pytest.fixture
+def get_now(time_zone):
+    def _f():
+        return datetime.now(time_zone)
+
+    return _f
 
 
 @pytest.fixture(autouse=True)
 def fixed_datetime(monkeypatch):
     monkeypatch.setattr(
-        sys.modules["aidial_adapter_bedrock.utils.cache"], "datetime", datetime
+        sys.modules["aidial_adapter_bedrock.utils.datetime"],
+        "datetime",
+        datetime,
     )
 
 
-async def test_basic_caching():
+async def test_basic_caching(get_now):
     calls = 0
 
     async def func(x: int):
         nonlocal calls
         calls += 1
-        return (datetime.now() + timedelta(minutes=5), x * 2)
+        return (get_now() + timedelta(minutes=5), x * 2)
 
     cached = ttl_cache(func)
 
@@ -60,15 +78,15 @@ async def test_no_expiry():
     assert calls == 1
 
 
-async def test_expiry_refresh():
+async def test_expiry_refresh(get_now):
     calls = 0
 
     async def func(x: int):
         nonlocal calls
         calls += 1
         if calls == 1:
-            return (datetime.now() + timedelta(seconds=30), "first")
-        return (datetime.now() + timedelta(minutes=5), "second")
+            return (get_now() + timedelta(seconds=30), "first")
+        return (get_now() + timedelta(minutes=5), "second")
 
     cached = ttl_cache(func)
 
@@ -82,12 +100,12 @@ async def test_expiry_refresh():
     assert calls == 2
 
 
-async def test_different_args_and_kwargs():
+async def test_different_args_and_kwargs(get_now):
     calls = []
 
     async def func(a: int, b: int = 0):
         calls.append((a, b))
-        return (datetime.now() + timedelta(minutes=5), a + b)
+        return (get_now() + timedelta(minutes=5), a + b)
 
     cached = ttl_cache(func)
 
@@ -101,7 +119,7 @@ async def test_different_args_and_kwargs():
     assert len(calls) == 2
 
 
-async def test_model_arg_serialization():
+async def test_model_arg_serialization(get_now):
     calls = 0
 
     class M(BaseModel):
@@ -110,7 +128,7 @@ async def test_model_arg_serialization():
     async def func(m: M):
         nonlocal calls
         calls += 1
-        return (datetime.now() + timedelta(minutes=5), m.x)
+        return (get_now() + timedelta(minutes=5), m.x)
 
     cached = ttl_cache(func)
 
@@ -160,14 +178,14 @@ async def test_args_kwargs_separate_keys():
     assert len(calls) == 2
 
 
-async def test_concurrent_requests():
+async def test_concurrent_requests(get_now):
     calls = 0
 
     async def func(x):
         nonlocal calls
         calls += 1
         await asyncio.sleep(0)
-        return (datetime.now() + timedelta(minutes=5), x)
+        return (get_now() + timedelta(minutes=5), x)
 
     n = 100
     cached = ttl_cache(func)


### PR DESCRIPTION
The adapter throws the following exception when `AWS_ASSUME_ROLE_ARN` env var is used:

```text
ERROR:    | 2025-06-02 12:05:08 | 1 | app | Caught exception: builtins.TypeError. The exception converted to the dial exception: InternalServerError(message="can't compare offset-naive and offset-aware datetimes", status_code=500, type='internal_server_error', param=None, code='500', display_message=None).
Traceback (most recent call last):
File "/app/aidial_adapter_bedrock/server/exceptions.py", line 210, in wrapper
  return await func(*args, **kwargs)
File "/app/aidial_adapter_bedrock/chat_completion.py", line 72, in chat_completion
  model = await self._get_model(request)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/aidial_adapter_bedrock/chat_completion.py", line 54, in _get_model
  return await get_bedrock_adapter(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/aidial_adapter_bedrock/llm/model/adapter.py", line 71, in get_bedrock_adapter
  return await claude_v3.create_adapter(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py", line 138, in create_adapter
  model = await Adapter.create(deployment, api_key, upstream_config)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py", line 503, in create
  client = await create_anthropic_client(upstream_config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/aidial_adapter_bedrock/utils/cache.py", line 31, in _wrapper
  elif expiry > datetime.now() + timedelta(minutes=1):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
```

The regression was introduced in https://github.com/epam/ai-dial-adapter-bedrock/pull/261

The fix is to compare all datetimes using UTC timezone.