### PR TITLE
fix: support function calling while thinking

### DIFF
--- a/aidial_adapter_bedrock/llm/message.py
+++ b/aidial_adapter_bedrock/llm/message.py
@@ -248,12 +248,14 @@ class AIRegularMessage(BaseMessageABC):
 class AIToolCallMessage(MessageABC):
     calls: List[ToolCall]
     content: Optional[str] = None
+    custom_content: Optional[CustomContent] = None
 
     def to_message(self) -> DialMessage:
         return DialMessage(
             role=Role.ASSISTANT,
             content=self.content,
             tool_calls=self.calls,
+            custom_content=self.custom_content,
             custom_fields=self.custom_fields,
         )
 
@@ -273,6 +275,7 @@ class AIToolCallMessage(MessageABC):
         return cls(
             calls=message.tool_calls,
             content=message.content,
+            custom_content=message.custom_content,
             cache_breakpoint=_get_cache_breakpoint(message),
         )
 

--- a/aidial_adapter_bedrock/llm/model/claude/v3/converters.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/converters.py
@@ -90,7 +90,7 @@ class MessageState(BaseModel):
 
 
 def _get_message_content_from_state(
-    idx: int, message: AIRegularMessage
+    idx: int, message: AIRegularMessage | AIToolCallMessage
 ) -> List[ContentBlockParam] | None:
     if (cc := message.custom_content) is not None and (
         state_dict := cc.state
@@ -313,14 +313,19 @@ async def to_claude_messages(
                 # since it may include certain content blocks that
                 # are missing from the DIAL message itself,
                 # such as thinking signatures and redacted thinking blocks.
-                content = _get_message_content_from_state(
-                    idx, message
-                ) or await _to_claude_message(file_storage, message)
+                content = _get_message_content_from_state(idx, message)
+                if content is None:
+                    content = await _to_claude_message(file_storage, message)
 
             case AIToolCallMessage():
-                content = [_to_claude_tool_call(call) for call in message.calls]
-                if message.content is not None:
-                    content.insert(0, _create_text_block(message.content))
+                content = _get_message_content_from_state(idx, message)
+
+                if content is None:
+                    content = [
+                        _to_claude_tool_call(call) for call in message.calls
+                    ]
+                    if message.content is not None:
+                        content.insert(0, _create_text_block(message.content))
 
             case HumanToolResultMessage():
                 content = [_to_claude_tool_result(message)]

--- a/tests/integration_tests/test_claude_thinking.py
+++ b/tests/integration_tests/test_claude_thinking.py
@@ -1,12 +1,22 @@
+from dataclasses import dataclass
 from typing import List, Mapping
 
 import pytest
-from openai.types.chat import ChatCompletionMessageParam
+from openai.types.chat import (
+    ChatCompletionMessageParam,
+    ChatCompletionToolMessageParam,
+)
 
 from aidial_adapter_bedrock.deployments import ChatCompletionDeployment
 from aidial_adapter_bedrock.llm.model.claude.v3.converters import MessageState
 from tests.integration_tests.test_chat_completion import Deployment
-from tests.utils.openai import chat_completion, user
+from tests.utils.openai import (
+    GET_WEATHER_FUNCTION,
+    chat_completion,
+    function_to_tool,
+    sanitize_test_name,
+    user,
+)
 
 _EAST = "us-east-1"
 
@@ -17,37 +27,58 @@ chat_deployments: Mapping[Deployment, str] = {
 }
 
 
-@pytest.mark.parametrize(
-    "deployment, region, stream",
-    [
-        (deployment, region, stream)
-        for deployment, region in chat_deployments.items()
-        for stream in [False, True]
-    ],
-)
-async def test_claude_thinking(
-    get_openai_client,
-    deployment: ChatCompletionDeployment,
-    region: str,
-    stream: bool,
-):
-    client = get_openai_client(deployment.value, region=region)
+def supports_parallel_tool_calls(deployment: ChatCompletionDeployment):
+    return deployment != ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_7_SONNET
 
-    messages: List[ChatCompletionMessageParam] = [user("2+3=?")]
 
-    configuration: dict = {
-        "custom_fields": {
-            "configuration": {
-                "thinking": {
-                    "type": "enabled",
-                    "budget_tokens": 1024,
-                }
+_CONFIGURATION = {
+    "custom_fields": {
+        "configuration": {
+            "thinking": {
+                "type": "enabled",
+                "budget_tokens": 1024,
             }
         }
     }
+}
+
+
+@dataclass
+class TestCase:
+    __test__ = False
+
+    deployment: Deployment
+    region: str
+    stream: bool
+
+    def get_id(self) -> str:
+        stream = "stream" if self.stream else "block"
+        return sanitize_test_name(
+            "/".join([stream, self.deployment.value, self.region])
+        )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(deployment, region, stream)
+        for deployment, region in chat_deployments.items()
+        for stream in [False, True]
+    ],
+    ids=lambda t: t.get_id(),
+)
+async def test_claude_thinking_no_function_calling(
+    get_openai_client, test_case: TestCase
+):
+    stream = test_case.stream
+    client = get_openai_client(
+        test_case.deployment.value, region=test_case.region
+    )
+
+    messages: List[ChatCompletionMessageParam] = [user("2+3=?")]
 
     response1 = await chat_completion(
-        client, messages=messages, stream=stream, extra_body=configuration
+        client, messages=messages, stream=stream, extra_body=_CONFIGURATION
     )
 
     bot_message1 = response1.response.choices[0].message
@@ -59,13 +90,87 @@ async def test_claude_thinking(
     messages.append(user("5+5=?"))
 
     response2 = await chat_completion(
-        client, messages=messages, stream=stream, extra_body=configuration
+        client, messages=messages, stream=stream, extra_body=_CONFIGURATION
     )
 
     bot_message2 = response2.response.choices[0].message
     state_dict2 = bot_message2.custom_content["state"]  # type: ignore
     state2 = MessageState.parse_obj(state_dict2)
     assert len(state2.claude_message_content) == 2
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(deployment, region, stream)
+        for deployment, region in chat_deployments.items()
+        for stream in [False, True]
+    ],
+    ids=lambda t: t.get_id(),
+)
+async def test_claude_thinking_with_function_calling(
+    get_openai_client, test_case: TestCase
+):
+    stream = test_case.stream
+    client = get_openai_client(
+        test_case.deployment.value, region=test_case.region
+    )
+
+    cities = ["Glasgow", "London"]
+    temps = [10, 23]
+    if not supports_parallel_tool_calls(test_case.deployment.origin):
+        cities = cities[:1]
+        temps = temps[:1]
+
+    messages: List[ChatCompletionMessageParam] = [
+        user(
+            f"Tell me what's the temperature in {' and in '.join(cities)} in celsius?"
+        )
+    ]
+
+    response1 = await chat_completion(
+        client,
+        messages=messages,
+        stream=stream,
+        tools=[function_to_tool(GET_WEATHER_FUNCTION)],
+        extra_body=_CONFIGURATION,
+    )
+
+    bot_message1 = response1.response.choices[0].message
+    state_dict1 = bot_message1.custom_content["state"]  # type: ignore
+    state1 = MessageState.parse_obj(state_dict1)
+    assert len(state1.claude_message_content) > 0
+
+    messages.append(bot_message1.dict())  # type: ignore
+
+    tool_calls = bot_message1.tool_calls
+    assert tool_calls is not None
+    assert len(tool_calls) == len(cities)
+
+    for tool_call, temp in zip(tool_calls, temps):
+        messages.append(
+            ChatCompletionToolMessageParam(
+                role="tool",
+                tool_call_id=tool_call.id,
+                content=f"{temp} degrees",
+            )
+        )
+
+    response2 = await chat_completion(
+        client,
+        messages=messages,
+        stream=stream,
+        tools=[function_to_tool(GET_WEATHER_FUNCTION)],
+        extra_body=_CONFIGURATION,
+    )
+
+    bot_message2 = response2.response.choices[0].message
+    state_dict2 = bot_message2.custom_content["state"]  # type: ignore
+    state2 = MessageState.parse_obj(state_dict2)
+    assert len(state2.claude_message_content) > 0
+
+    for temp in temps:
+        assert str(temp) in (bot_message2.content or "")
 
 
 # NOTE: according to the Anthropic docs,

--- a/tests/integration_tests/test_claude_thinking.py
+++ b/tests/integration_tests/test_claude_thinking.py
@@ -53,9 +53,7 @@ class TestCase:
 
     def get_id(self) -> str:
         stream = "stream" if self.stream else "block"
-        return sanitize_test_name(
-            "/".join([stream, self.deployment.value, self.region])
-        )
+        return sanitize_test_name(f"{stream}/{self.deployment.value}")
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/openai.py
+++ b/tests/utils/openai.py
@@ -332,12 +332,12 @@ GET_WEATHER_FUNCTION: Function = {
         "properties": {
             "location": {
                 "type": "string",
-                "description": "The city and state, e.g. San Francisco, CA",
+                "description": "The city e.g. San Francisco",
             },
             "unit": {
                 "type": "string",
                 "enum": ["celsius", "fahrenheit"],
-                "description": "The temperature unit to use. Infer this from the users location.",
+                "description": "The temperature unit to use. Infer this from the users request or location.",
             },
         },
         "required": ["location", "unit"],


### PR DESCRIPTION
Thinking blocks in tool-calling assistant messages weren't picked by the adapter.

This made function calling in thinking mode impossible and resulted in the error:

> Error code: 400 - {'error': {'message': 'messages.1.content.0.type: Expected `thinking` or `redacted_thinking`, but found `text`. When `thinking` is enabled, a final `assistant` message must start with a thinking block (preceeding the lastmost set of `tool_use` and `tool_result` blocks). We recommend you include thinking blocks from previous turns. To avoid this requirement, disable `thinking`. Please consult our documentation at https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking', 'type': 'invalid_request_error', 'code': '400'}}"
