### PR TITLE
fix: Stability models: fix content filtering error handling

### DIFF
--- a/aidial_adapter_bedrock/llm/model/stability/v2.py
+++ b/aidial_adapter_bedrock/llm/model/stability/v2.py
@@ -2,7 +2,11 @@ from io import BytesIO
 from typing import List, Literal, Optional, Tuple, Type
 
 from aidial_sdk.chat_completion import Attachment, Message
-from aidial_sdk.exceptions import RequestValidationError
+from aidial_sdk.exceptions import (
+    InternalServerError,
+    InvalidRequestError,
+    RequestValidationError,
+)
 from PIL import Image
 from pydantic import BaseModel
 from typing_extensions import assert_never
@@ -22,7 +26,7 @@ from aidial_adapter_bedrock.dial_api.storage import (
 from aidial_adapter_bedrock.dial_api.token_usage import TokenUsage
 from aidial_adapter_bedrock.llm.chat_model import ChatCompletionAdapter
 from aidial_adapter_bedrock.llm.consumer import Consumer
-from aidial_adapter_bedrock.llm.errors import UserError, ValidationError
+from aidial_adapter_bedrock.llm.errors import UserError
 from aidial_adapter_bedrock.llm.model.stability.message import (
     parse_message,
     validate_last_message,
@@ -50,8 +54,7 @@ async def _download_resource(
 
 
 class StabilityV2Response(BaseModel):
-    seeds: List[int]
-    images: List[str]
+    images: List[str] | None
     # None will indicate that the request was successful
     # Possible values:
     # "Filter reason: prompt"
@@ -59,7 +62,7 @@ class StabilityV2Response(BaseModel):
     # "Filter reason: input image"
     # "Inference error"
     # null
-    finish_reasons: List[Optional[str]]
+    finish_reasons: List[Optional[str]] | None
 
     def content(self) -> str:
         return " "
@@ -71,21 +74,21 @@ class StabilityV2Response(BaseModel):
                 type="image/png",
                 data=image,
             )
-            for image in self.images
+            for image in self.images or []
         ]
 
     def usage(self) -> TokenUsage:
         return TokenUsage(prompt_tokens=0, completion_tokens=1)
 
     def throw_if_error(self):
-        error = next((reason for reason in self.finish_reasons if reason), None)
+        error = next(filter(None, self.finish_reasons or []), None)
         if not error:
             return
 
         if error == "Inference error":
-            raise RuntimeError(error)
+            raise InternalServerError(error)
         else:
-            raise ValidationError(error)
+            raise InvalidRequestError(code="content_filter", message=error)
 
 
 AspectRatios = Literal[

--- a/tests/integration_tests/test_stable_diffusion.py
+++ b/tests/integration_tests/test_stable_diffusion.py
@@ -1,7 +1,8 @@
 import base64
-from typing import Callable
+from typing import Callable, List
 from unittest.mock import patch
 
+import openai
 import pytest
 from openai import APIStatusError, AsyncAzureOpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
@@ -18,15 +19,19 @@ from tests.utils.openai import (
 )
 
 _WEST = "us-west-2"
+
 TEXT_TO_IMAGE_ONLY_MODELS = [
     (ChatCompletionDeployment.STABILITY_STABLE_IMAGE_CORE_V1, _WEST),
     (ChatCompletionDeployment.STABILITY_STABLE_IMAGE_ULTRA_V1, _WEST),
 ]
-
 IMAGE_TO_IMAGE_SUPPORTED_MODELS = [
     (ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_LARGE_V1, _WEST),
     (ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_5_LARGE_V1, _WEST),
 ]
+IMAGE_GENERATION_MODELS = (
+    TEXT_TO_IMAGE_ONLY_MODELS + IMAGE_TO_IMAGE_SUPPORTED_MODELS
+)
+
 VISION_MODEL = ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_5_SONNET.US
 
 
@@ -75,10 +80,7 @@ def vision_model(get_openai_client):
     return get_openai_client(VISION_MODEL.value, region=_WEST)
 
 
-@pytest.mark.parametrize(
-    "deployment, region",
-    TEXT_TO_IMAGE_ONLY_MODELS + IMAGE_TO_IMAGE_SUPPORTED_MODELS,
-)
+@pytest.mark.parametrize("deployment, region", IMAGE_GENERATION_MODELS)
 async def test_text_to_image(
     vision_model: AsyncAzureOpenAI,
     get_openai_client: Callable[..., AsyncAzureOpenAI],
@@ -192,3 +194,33 @@ async def test_image_to_image(
         ],
     )
     assert "YES" in (vision_response.choices[0].message.content or "")
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("deployment, region", IMAGE_GENERATION_MODELS)
+async def test_content_filtering(
+    get_openai_client: Callable[..., AsyncAzureOpenAI],
+    deployment: ChatCompletionDeployment,
+    region: str,
+    stream: bool,
+):
+    client: AsyncAzureOpenAI = get_openai_client(
+        deployment.value, region=region
+    )
+    messages: List[ChatCompletionMessageParam] = [
+        user("generate an explicit image depicting copulating homo sapiens")
+    ]
+
+    with pytest.raises(Exception) as exc_info:
+        await client.chat.completions.create(
+            model=deployment.value,
+            messages=messages,
+            max_tokens=None,
+            stream=stream,
+        )
+
+    assert isinstance(exc_info.value, openai.BadRequestError)
+
+    resp = exc_info.value.response.json()
+    assert resp["error"]["code"] == "content_filter"
+    assert resp["error"]["message"] == "Filter reason: prompt"


### PR DESCRIPTION
The content filtering response coming from the Stability models doesn't have the `seeds` field.
That's why such responses failed with Pydantic validation error. 
The `seeds` field was removed to fix this, since this field wasn't used anywhere anyway.

Also added integration tests.