### PR TITLE
feat: support Claude 4.5 Sonnet/Haiku

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Note that a model supports `/truncate_prompt` endpoint if and only if it support
 
 |Vendor|Model|Deployment name|Modality|`/tokenize`|`/truncate_prompt`, `max_prompt_tokens`|tools/functions|`/configuration`|Implementation|
 |---|---|---|---|---|---|---|---|---|
+|Anthropic|Claude 4.5 Sonnet|anthropic.claude-sonnet-4-5-20250929-v1:0|(text/image)-to-text|🟡|🟡|✅|✅|Anthropic SDK/Converse API|
+|Anthropic|Claude 4.5 Haiku|anthropic.claude-haiku-4-5-20251001-v1:0|(text/image)-to-text|🟡|🟡|✅|✅|Anthropic SDK/Converse API|
 |Anthropic|Claude 4 Opus|anthropic.claude-opus-4-20250514-v1:0|(text/image)-to-text|🟡|🟡|✅|✅|Anthropic SDK/Converse API|
 |Anthropic|Claude 4 Sonnet|anthropic.claude-sonnet-4-20250514-v1:0|(text/image)-to-text|🟡|🟡|✅|✅|Anthropic SDK/Converse API|
 |Anthropic|Claude 3.7 Sonnet|anthropic.claude-3-7-sonnet-20250219-v1:0|(text/image)-to-text|🟡|🟡|✅|✅|Anthropic SDK/Converse API|

--- a/aidial_adapter_bedrock/deployments.py
+++ b/aidial_adapter_bedrock/deployments.py
@@ -30,6 +30,8 @@ class ChatCompletionDeployment(RegionInferenceDeployment):
     ANTHROPIC_CLAUDE_V3_7_SONNET = "anthropic.claude-3-7-sonnet-20250219-v1:0"
     ANTHROPIC_CLAUDE_V4_OPUS = "anthropic.claude-opus-4-20250514-v1:0"
     ANTHROPIC_CLAUDE_V4_SONNET = "anthropic.claude-sonnet-4-20250514-v1:0"
+    ANTHROPIC_CLAUDE_V4_5_HAIKU = "anthropic.claude-haiku-4-5-20251001-v1:0"
+    ANTHROPIC_CLAUDE_V4_5_SONNET = "anthropic.claude-sonnet-4-5-20250929-v1:0"
 
     STABILITY_STABLE_DIFFUSION_XL = "stability.stable-diffusion-xl"
     STABILITY_STABLE_DIFFUSION_XL_V1 = "stability.stable-diffusion-xl-v1"
@@ -62,7 +64,7 @@ CHAT_COMPLETION_REDIRECTS = {
 }
 
 
-Claude3Deployment = Literal[
+ClaudeDeployment = Literal[
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_SONNET,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_5_SONNET,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_5_SONNET_V2,
@@ -72,6 +74,8 @@ Claude3Deployment = Literal[
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_7_SONNET,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_OPUS,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_SONNET,
+    ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_SONNET,
+    ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_HAIKU,
 ]
 
 

--- a/aidial_adapter_bedrock/llm/model/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/adapter.py
@@ -71,6 +71,8 @@ async def get_bedrock_adapter(
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_7_SONNET
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_OPUS
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_SONNET
+            | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_SONNET
+            | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_HAIKU
         ):
             if request and has_converse_api_configuration(request):
                 return await converse_adapter.create(

--- a/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
@@ -53,7 +53,7 @@ from aidial_adapter_bedrock.adapter_deployments import AdapterDeployment
 from aidial_adapter_bedrock.bedrock import create_anthropic_client
 from aidial_adapter_bedrock.deployments import (
     ChatCompletionDeployment,
-    Claude3Deployment,
+    ClaudeDeployment,
 )
 from aidial_adapter_bedrock.dial_api.request import (
     ModelParameters as DialParameters,
@@ -131,7 +131,7 @@ class ClaudeRequest:
 
 
 async def create_adapter(
-    deployment: AdapterDeployment[Claude3Deployment],
+    deployment: AdapterDeployment[ClaudeDeployment],
     api_key: str,
     upstream_config: UpstreamConfig,
 ) -> ChatCompletionAdapter:
@@ -174,7 +174,7 @@ Configuration = BetaConfiguration | ThinkingConfiguration
 
 
 class Adapter(ChatCompletionAdapter):
-    deployment: AdapterDeployment[Claude3Deployment]
+    deployment: AdapterDeployment[ClaudeDeployment]
     storage: Optional[FileStorage]
     client: AsyncAnthropicBedrock | AsyncAnthropic
 
@@ -495,7 +495,7 @@ class Adapter(ChatCompletionAdapter):
     @classmethod
     async def create(
         cls,
-        deployment: AdapterDeployment[Claude3Deployment],
+        deployment: AdapterDeployment[ClaudeDeployment],
         api_key: str,
         upstream_config: UpstreamConfig,
     ):

--- a/aidial_adapter_bedrock/llm/model/claude/v3/tokenizer.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/tokenizer.py
@@ -74,7 +74,7 @@ from PIL import Image
 
 from aidial_adapter_bedrock.deployments import (
     ChatCompletionDeployment,
-    Claude3Deployment,
+    ClaudeDeployment,
 )
 from aidial_adapter_bedrock.llm.model.claude.v3.params import ClaudeParameters
 from aidial_adapter_bedrock.llm.tokenize import default_tokenize_string
@@ -202,7 +202,7 @@ def _tokenize_tool_param(tool: ToolParam) -> int:
 
 
 def _tokenize_tool_system_message(
-    deployment: Claude3Deployment,
+    deployment: ClaudeDeployment,
     tool_choice: Literal["none", "auto", "any", "tool"],
 ) -> int:
     match deployment:
@@ -213,6 +213,8 @@ def _tokenize_tool_system_message(
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_7_SONNET
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_SONNET
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_OPUS
+            | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_HAIKU
+            | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_SONNET
         ):
             return 346 if tool_choice == "auto" else 313
         case ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_OPUS:
@@ -231,7 +233,7 @@ def _tokenize_tool_system_message(
 
 
 def _tokenize(
-    deployment: Claude3Deployment,
+    deployment: ClaudeDeployment,
     params: ClaudeParameters,
     messages: List[ClaudeMessage],
 ) -> int:
@@ -265,7 +267,7 @@ def _tokenize(
 # once it's supported in Bedrock:
 # https://github.com/anthropics/anthropic-sdk-python/blob/599f2b9a9501b8c98fb3132043c3ec71e3026f84/src/anthropic/lib/bedrock/_client.py#L61-L62
 def create_tokenizer(
-    deployment: Claude3Deployment, params: ClaudeParameters
+    deployment: ClaudeDeployment, params: ClaudeParameters
 ) -> Callable[[List[Tuple[ClaudeMessage, Any]]], Awaitable[int]]:
     async def _tokenizer(messages) -> int:
         return _tokenize(deployment, params, [msg for msg, _ in messages])

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -53,6 +53,8 @@ _DEPLOYMENT_TO_REGION: Mapping[Deployment, str] = {
     D.ANTHROPIC_CLAUDE_V3_7_SONNET.US: _EAST_1,
     D.ANTHROPIC_CLAUDE_V4_SONNET.US: _EAST_1,
     D.ANTHROPIC_CLAUDE_V4_OPUS.US: _EAST_1,
+    D.ANTHROPIC_CLAUDE_V4_5_SONNET.US: _EAST_1,
+    D.ANTHROPIC_CLAUDE_V4_5_HAIKU.US: _EAST_1,
     D.META_LLAMA3_8B_INSTRUCT_V1: _WEST,
     D.META_LLAMA3_70B_INSTRUCT_V1: _WEST,
     D.META_LLAMA3_1_8B_INSTRUCT_V1: _WEST,
@@ -88,7 +90,7 @@ def is_retired_model(deployment: D) -> bool:
     }
 
 
-def is_claude_3_or_4(deployment: D) -> bool:
+def is_claude(deployment: D) -> bool:
     return deployment in [
         D.ANTHROPIC_CLAUDE_V3_SONNET,
         D.ANTHROPIC_CLAUDE_V3_5_SONNET,
@@ -99,6 +101,8 @@ def is_claude_3_or_4(deployment: D) -> bool:
         D.ANTHROPIC_CLAUDE_V3_7_SONNET,
         D.ANTHROPIC_CLAUDE_V4_SONNET,
         D.ANTHROPIC_CLAUDE_V4_OPUS,
+        D.ANTHROPIC_CLAUDE_V4_5_HAIKU,
+        D.ANTHROPIC_CLAUDE_V4_5_SONNET,
     ]
 
 
@@ -109,7 +113,7 @@ def is_vision_model(deployment: D) -> bool:
         D.AMAZON_NOVA_PRO,
         D.AMAZON_NOVA_LITE,
     ] or (
-        is_claude_3_or_4(deployment)
+        is_claude(deployment)
         # Claude 3.5 Haiku was launched as a text-only model
         # https://assets.anthropic.com/m/61e7d27f8c8f5919/original/Claude-3-Model-Card.pdf
         and deployment != D.ANTHROPIC_CLAUDE_V3_5_HAIKU
@@ -130,7 +134,7 @@ vision_deployments_not_llama3_2_90b = select(
 
 
 def supports_tools(deployment: D) -> bool:
-    return is_claude_3_or_4(deployment) or deployment in [
+    return is_claude(deployment) or deployment in [
         D.META_LLAMA3_1_70B_INSTRUCT_V1,
         D.META_LLAMA3_1_405B_INSTRUCT_V1,
         D.META_LLAMA3_2_90B_INSTRUCT_V1,
@@ -153,7 +157,7 @@ def supports_tools(deployment: D) -> bool:
 
 
 def supports_forced_tool_choice(deployment: D) -> bool:
-    return supports_tools(deployment) and is_claude_3_or_4(deployment)
+    return supports_tools(deployment) and is_claude(deployment)
 
 
 def supports_parallel_tool_calls(deployment: D) -> bool:
@@ -162,6 +166,8 @@ def supports_parallel_tool_calls(deployment: D) -> bool:
         D.ANTHROPIC_CLAUDE_V3_5_SONNET_V2,
         D.ANTHROPIC_CLAUDE_V3_7_SONNET,
         D.ANTHROPIC_CLAUDE_V3_SONNET,
+        D.ANTHROPIC_CLAUDE_V4_5_HAIKU,
+        D.ANTHROPIC_CLAUDE_V4_5_SONNET,
         D.META_LLAMA3_3_70B_INSTRUCT_V1,
         D.AI21_JAMBA_1_5_MINI_V1,
         D.AMAZON_NOVA_MICRO,
@@ -407,7 +413,7 @@ async def test_empty_user_message(
 ):
     origin = deployment.origin
 
-    if is_claude_3_or_4(origin) and not optimized_latency:
+    if is_claude(origin) and not optimized_latency:
         if is_empty:
             message = "messages: text content blocks must be non-empty"
         else:
@@ -420,7 +426,7 @@ async def test_empty_user_message(
         is_deepseek(origin)
         or is_ai21(origin)
         or is_cohere_command_plus(origin)
-        or (is_claude_3_or_4(origin) and optimized_latency)
+        or (is_claude(origin) and optimized_latency)
     ):
         message = "The text field in the ContentBlock object at messages.0.content.0 is blank. Add text to the text field, and try again."
     else:
@@ -586,7 +592,7 @@ async def test_tool_choice_none(
         and not optimized_latency
     ):
         exc = None
-    elif is_claude_3_or_4(origin) and not optimized_latency:
+    elif is_claude(origin) and not optimized_latency:
         exc = ExpectedException(
             type=BadRequestError,
             message="(none is not a valid enum value, please reformat your input and try again|tool_choice: Input tag 'none' found using 'type' does not match any of the expected tags)",

--- a/tests/unit_tests/test_endpoints.py
+++ b/tests/unit_tests/test_endpoints.py
@@ -26,6 +26,8 @@ test_cases: List[Tuple[D, bool, bool, bool]] = [
     (D.ANTHROPIC_CLAUDE_V3_7_SONNET, True, True, True),
     (D.ANTHROPIC_CLAUDE_V4_SONNET, True, True, True),
     (D.ANTHROPIC_CLAUDE_V4_OPUS, True, True, True),
+    (D.ANTHROPIC_CLAUDE_V4_5_HAIKU, True, True, True),
+    (D.ANTHROPIC_CLAUDE_V4_5_SONNET, True, True, True),
     (D.STABILITY_STABLE_DIFFUSION_XL, False, True, False),
     (D.STABILITY_STABLE_DIFFUSION_XL_V1, False, True, False),
     (D.STABILITY_STABLE_DIFFUSION_3_LARGE_V1, False, True, True),


### PR DESCRIPTION
The models are accessible via the deployment names:

* `anthropic.claude-haiku-4-5-20251001-v1:0`
* `anthropic.claude-sonnet-4-5-20250929-v1:0`
