### PR TITLE
feat: support Claude 4.1 Opus

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Note that a model supports `/truncate_prompt` endpoint if and only if it support
 |---|---|---|---|---|---|---|---|---|
 |Anthropic|Claude 4.5 Sonnet|anthropic.claude-sonnet-4-5-20250929-v1:0|(text/image)-to-text|🟡|🟡|✅|✅|Anthropic SDK/Converse API|
 |Anthropic|Claude 4.5 Haiku|anthropic.claude-haiku-4-5-20251001-v1:0|(text/image)-to-text|🟡|🟡|✅|✅|Anthropic SDK/Converse API|
+|Anthropic|Claude 4.1 Opus|anthropic.claude-opus-4-20250514-v1:0|(text/image)-to-text|🟡|🟡|✅|✅|Anthropic SDK/Converse API|
 |Anthropic|Claude 4 Opus|anthropic.claude-opus-4-20250514-v1:0|(text/image)-to-text|🟡|🟡|✅|✅|Anthropic SDK/Converse API|
 |Anthropic|Claude 4 Sonnet|anthropic.claude-sonnet-4-20250514-v1:0|(text/image)-to-text|🟡|🟡|✅|✅|Anthropic SDK/Converse API|
 |Anthropic|Claude 3.7 Sonnet|anthropic.claude-3-7-sonnet-20250219-v1:0|(text/image)-to-text|🟡|🟡|✅|✅|Anthropic SDK/Converse API|

--- a/aidial_adapter_bedrock/deployments.py
+++ b/aidial_adapter_bedrock/deployments.py
@@ -29,6 +29,7 @@ class ChatCompletionDeployment(RegionInferenceDeployment):
     ANTHROPIC_CLAUDE_V3_OPUS = "anthropic.claude-3-opus-20240229-v1:0"
     ANTHROPIC_CLAUDE_V3_7_SONNET = "anthropic.claude-3-7-sonnet-20250219-v1:0"
     ANTHROPIC_CLAUDE_V4_OPUS = "anthropic.claude-opus-4-20250514-v1:0"
+    ANTHROPIC_CLAUDE_V4_1_OPUS = "anthropic.claude-opus-4-1-20250805-v1:0"
     ANTHROPIC_CLAUDE_V4_SONNET = "anthropic.claude-sonnet-4-20250514-v1:0"
     ANTHROPIC_CLAUDE_V4_5_HAIKU = "anthropic.claude-haiku-4-5-20251001-v1:0"
     ANTHROPIC_CLAUDE_V4_5_SONNET = "anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -72,6 +73,7 @@ ClaudeDeployment = Literal[
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_5_HAIKU,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_OPUS,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_7_SONNET,
+    ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_1_OPUS,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_OPUS,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_SONNET,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_SONNET,

--- a/aidial_adapter_bedrock/llm/model/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/adapter.py
@@ -70,6 +70,7 @@ async def get_bedrock_adapter(
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_OPUS
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_7_SONNET
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_OPUS
+            | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_1_OPUS
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_SONNET
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_SONNET
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_HAIKU

--- a/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
@@ -204,7 +204,10 @@ class Adapter(ChatCompletionAdapter):
         return self.deployment.reference_deployment_id in {
             ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_7_SONNET,
             ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_OPUS,
+            ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_1_OPUS,
             ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_SONNET,
+            ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_HAIKU,
+            ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_SONNET,
         }
 
     async def configuration(self) -> Type[Configuration]:

--- a/aidial_adapter_bedrock/llm/model/claude/v3/tokenizer.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/tokenizer.py
@@ -239,6 +239,7 @@ def _tokenize_tool_system_message(
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_7_SONNET
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_SONNET
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_OPUS
+            | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_1_OPUS
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_HAIKU
             | ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_SONNET
         ):

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -417,24 +417,21 @@ async def test_empty_dialog(chat: Chat):
     "is_empty", [True, False], ids=lambda b: "empty" if b else "non-empty"
 )
 async def test_empty_user_message(
-    deployment: Deployment, optimized_latency: bool, is_empty: bool, chat: Chat
+    deployment: Deployment, is_empty: bool, chat: Chat
 ):
     origin = deployment.origin
 
-    if is_claude(origin) and not optimized_latency:
-        if is_empty:
-            message = "messages: text content blocks must be non-empty"
-        else:
-            message = (
-                "messages: text content blocks must contain non-whitespace text"
-            )
+    if is_claude(origin) and not is_empty:
+        message = (
+            "messages: text content blocks must contain non-whitespace text"
+        )
     elif is_llama3(origin) or is_nova(origin):
         message = "Add text to the text field, and try again."
     elif (
         is_deepseek(origin)
         or is_ai21(origin)
         or is_cohere_command_plus(origin)
-        or (is_claude(origin) and optimized_latency)
+        or is_claude(origin)
     ):
         message = "The text field in the ContentBlock object at messages.0.content.0 is blank. Add text to the text field, and try again."
     else:

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -450,9 +450,9 @@ async def test_empty_user_message(
             message = "Value error, message content must not be an empty string"
     elif is_empty and (
         is_cohere_command_plus(origin)
-        or (is_llama3(origin))
-        or (is_nova(origin))
-        or (is_deepseek(origin))
+        or is_llama3(origin)
+        or is_nova(origin)
+        or is_deepseek(origin)
     ):
         message = converse_api_error_message
     else:

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -615,6 +615,8 @@ async def test_tool_choice_none(
             D.ANTHROPIC_CLAUDE_V4_1_OPUS,
             D.ANTHROPIC_CLAUDE_V4_SONNET,
             D.ANTHROPIC_CLAUDE_V3_7_SONNET,
+            D.ANTHROPIC_CLAUDE_V4_5_HAIKU,
+            D.ANTHROPIC_CLAUDE_V4_5_SONNET,
         ]
         and not optimized_latency
     ):

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -53,6 +53,7 @@ _DEPLOYMENT_TO_REGION: Mapping[Deployment, str] = {
     D.ANTHROPIC_CLAUDE_V3_7_SONNET.US: _EAST_1,
     D.ANTHROPIC_CLAUDE_V4_SONNET.US: _EAST_1,
     D.ANTHROPIC_CLAUDE_V4_OPUS.US: _EAST_1,
+    D.ANTHROPIC_CLAUDE_V4_1_OPUS.US: _EAST_1,
     D.ANTHROPIC_CLAUDE_V4_5_SONNET.US: _EAST_1,
     D.ANTHROPIC_CLAUDE_V4_5_HAIKU.US: _EAST_1,
     D.META_LLAMA3_8B_INSTRUCT_V1: _WEST,
@@ -75,6 +76,9 @@ _DEPLOYMENT_TO_REGION: Mapping[Deployment, str] = {
     D.DEEPSEEK_R1_V2.US: _EAST_1,
     D.STABILITY_STABLE_DIFFUSION_XL: _WEST,
     D.STABILITY_STABLE_DIFFUSION_XL_V1: _WEST,
+    D.STABILITY_STABLE_IMAGE_CORE_V1: _WEST,
+    D.STABILITY_STABLE_IMAGE_ULTRA_V1: _WEST,
+    D.STABILITY_STABLE_DIFFUSION_3_LARGE_V1: _WEST,
 }
 
 
@@ -87,6 +91,9 @@ def is_retired_model(deployment: D) -> bool:
         D.AI21_J2_ULTRA_V1,
         D.STABILITY_STABLE_DIFFUSION_XL,
         D.STABILITY_STABLE_DIFFUSION_XL_V1,
+        D.STABILITY_STABLE_IMAGE_CORE_V1,
+        D.STABILITY_STABLE_IMAGE_ULTRA_V1,
+        D.STABILITY_STABLE_DIFFUSION_3_LARGE_V1,
     }
 
 
@@ -101,6 +108,7 @@ def is_claude(deployment: D) -> bool:
         D.ANTHROPIC_CLAUDE_V3_7_SONNET,
         D.ANTHROPIC_CLAUDE_V4_SONNET,
         D.ANTHROPIC_CLAUDE_V4_OPUS,
+        D.ANTHROPIC_CLAUDE_V4_1_OPUS,
         D.ANTHROPIC_CLAUDE_V4_5_HAIKU,
         D.ANTHROPIC_CLAUDE_V4_5_SONNET,
     ]
@@ -359,7 +367,7 @@ async def test_text_content_parts_in_assistant_message(
                     {"type": "text", "text": "13"},
                 ]
             ),
-            user("compute (11+22). Reply with a number."),
+            user("compute (11+22). Reply with a single number."),
         ],
         max_tokens=10 if not is_reasoning_model(deployment.origin) else 512,
     )
@@ -586,6 +594,7 @@ async def test_tool_choice_none(
         origin
         in [
             D.ANTHROPIC_CLAUDE_V4_OPUS,
+            D.ANTHROPIC_CLAUDE_V4_1_OPUS,
             D.ANTHROPIC_CLAUDE_V4_SONNET,
             D.ANTHROPIC_CLAUDE_V3_7_SONNET,
         ]

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -417,23 +417,44 @@ async def test_empty_dialog(chat: Chat):
     "is_empty", [True, False], ids=lambda b: "empty" if b else "non-empty"
 )
 async def test_empty_user_message(
-    deployment: Deployment, is_empty: bool, chat: Chat
+    deployment: Deployment,
+    optimized_latency: bool,
+    stream: bool,
+    is_empty: bool,
+    chat: Chat,
 ):
     origin = deployment.origin
 
-    if is_claude(origin) and not is_empty:
-        message = (
-            "messages: text content blocks must contain non-whitespace text"
-        )
-    elif is_llama3(origin) or is_nova(origin):
-        message = "Add text to the text field, and try again."
-    elif (
-        is_deepseek(origin)
-        or is_ai21(origin)
-        or is_cohere_command_plus(origin)
-        or is_claude(origin)
+    if is_ai21(origin) and stream and not is_empty:
+        pytest.skip("A21 hangs indefinitely on this input")
+
+    converse_api_error_message = "The text field in the ContentBlock object at messages.0.content.0 is blank. Add text to the text field, and try again."
+
+    if is_claude(origin):
+        if (
+            origin == D.ANTHROPIC_CLAUDE_V3_5_HAIKU
+            and is_empty
+            and optimized_latency
+        ):
+            message = converse_api_error_message
+        elif is_empty:
+            message = "messages: text content blocks must be non-empty"
+        else:
+            message = (
+                "messages: text content blocks must contain non-whitespace text"
+            )
+    elif is_ai21(origin):
+        if is_empty:
+            message = converse_api_error_message
+        else:
+            message = "Value error, message content must not be an empty string"
+    elif is_empty and (
+        is_cohere_command_plus(origin)
+        or (is_llama3(origin))
+        or (is_nova(origin))
+        or (is_deepseek(origin))
     ):
-        message = "The text field in the ContentBlock object at messages.0.content.0 is blank. Add text to the text field, and try again."
+        message = converse_api_error_message
     else:
         message = None
 

--- a/tests/integration_tests/test_claude_thinking.py
+++ b/tests/integration_tests/test_claude_thinking.py
@@ -23,7 +23,10 @@ _EAST = "us-east-1"
 chat_deployments: Mapping[Deployment, str] = {
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_7_SONNET.US: _EAST,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_OPUS.US: _EAST,
+    ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_1_OPUS.US: _EAST,
     ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_SONNET.US: _EAST,
+    ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_HAIKU.US: _EAST,
+    ChatCompletionDeployment.ANTHROPIC_CLAUDE_V4_5_SONNET.US: _EAST,
 }
 
 

--- a/tests/integration_tests/test_stable_diffusion.py
+++ b/tests/integration_tests/test_stable_diffusion.py
@@ -20,17 +20,9 @@ from tests.utils.openai import (
 
 _WEST = "us-west-2"
 
-TEXT_TO_IMAGE_ONLY_MODELS = [
-    (ChatCompletionDeployment.STABILITY_STABLE_IMAGE_CORE_V1, _WEST),
-    (ChatCompletionDeployment.STABILITY_STABLE_IMAGE_ULTRA_V1, _WEST),
-]
 IMAGE_TO_IMAGE_SUPPORTED_MODELS = [
-    (ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_LARGE_V1, _WEST),
     (ChatCompletionDeployment.STABILITY_STABLE_DIFFUSION_3_5_LARGE_V1, _WEST),
 ]
-IMAGE_GENERATION_MODELS = (
-    TEXT_TO_IMAGE_ONLY_MODELS + IMAGE_TO_IMAGE_SUPPORTED_MODELS
-)
 
 VISION_MODEL = ChatCompletionDeployment.ANTHROPIC_CLAUDE_V3_5_SONNET.US
 
@@ -80,7 +72,7 @@ def vision_model(get_openai_client):
     return get_openai_client(VISION_MODEL.value, region=_WEST)
 
 
-@pytest.mark.parametrize("deployment, region", IMAGE_GENERATION_MODELS)
+@pytest.mark.parametrize("deployment, region", IMAGE_TO_IMAGE_SUPPORTED_MODELS)
 async def test_text_to_image(
     vision_model: AsyncAzureOpenAI,
     get_openai_client: Callable[..., AsyncAzureOpenAI],
@@ -112,23 +104,6 @@ async def test_text_to_image(
         ],
     )
     assert "YES" in (vision_response.choices[0].message.content or "")
-
-
-@pytest.mark.parametrize("deployment, region", TEXT_TO_IMAGE_ONLY_MODELS)
-async def test_image_to_image_unsupported(
-    get_openai_client: Callable[..., AsyncAzureOpenAI],
-    deployment: ChatCompletionDeployment,
-    region: str,
-):
-    client = get_openai_client(deployment.value, region=region)
-
-    with pytest.raises(APIStatusError) as exc_info:
-        await client.chat.completions.create(
-            model=deployment.value,
-            messages=[user_with_image_content_part("Brown dog", DOG_PICTURE)],
-        )
-    assert exc_info.value.status_code == 422
-    assert "Image-to-Image is not supported" in exc_info.value.message
 
 
 @pytest.mark.parametrize("deployment, region", IMAGE_TO_IMAGE_SUPPORTED_MODELS)
@@ -197,7 +172,7 @@ async def test_image_to_image(
 
 
 @pytest.mark.parametrize("stream", [False, True])
-@pytest.mark.parametrize("deployment, region", IMAGE_GENERATION_MODELS)
+@pytest.mark.parametrize("deployment, region", IMAGE_TO_IMAGE_SUPPORTED_MODELS)
 async def test_content_filtering(
     get_openai_client: Callable[..., AsyncAzureOpenAI],
     deployment: ChatCompletionDeployment,

--- a/tests/unit_tests/test_endpoints.py
+++ b/tests/unit_tests/test_endpoints.py
@@ -26,6 +26,7 @@ test_cases: List[Tuple[D, bool, bool, bool]] = [
     (D.ANTHROPIC_CLAUDE_V3_7_SONNET, True, True, True),
     (D.ANTHROPIC_CLAUDE_V4_SONNET, True, True, True),
     (D.ANTHROPIC_CLAUDE_V4_OPUS, True, True, True),
+    (D.ANTHROPIC_CLAUDE_V4_1_OPUS, True, True, True),
     (D.ANTHROPIC_CLAUDE_V4_5_HAIKU, True, True, True),
     (D.ANTHROPIC_CLAUDE_V4_5_SONNET, True, True, True),
     (D.STABILITY_STABLE_DIFFUSION_XL, False, True, False),

--- a/tests/utils/exception.py
+++ b/tests/utils/exception.py
@@ -48,8 +48,12 @@ async def expected_exception(
 
         assert isinstance(
             e, cls
-        ), f"Actual exception type ({type(e)}) doesn't match the expected one ({cls})"
+        ), f"The actual exception type ({type(e)}) doesn't match the expected one ({cls})"
         actual_status_code = getattr(e, "status_code", None)
         assert actual_status_code == status_code
-        assert re.search(message, str(e))
+        assert re.search(
+            message, str(e)
+        ), f"The actual error message ({str(e)!r}) doesn't match the expected regexp ({message!r})"
         assert (e.body or {}).get("display_message") == display_message  # type: ignore
+    else:
+        assert False, f"The test didn't raise the expected exception {cls}"


### PR DESCRIPTION
The model is accessible via `anthropic.claude-opus-4-20250514-v1:0` id.

Also:
* declared Claude 4.5 models as supporting thinking _(following the recent PR https://github.com/epam/ai-dial-adapter-bedrock/pull/318)_
* actualised integration tests _(including retirement of a few Stability models, see #322)_