### PR TITLE
fix: fix incorrect handling of discarded messages

### DIFF
--- a/aidial_adapter_bedrock/llm/decorator/preprocess_messages.py
+++ b/aidial_adapter_bedrock/llm/decorator/preprocess_messages.py
@@ -13,7 +13,7 @@ from aidial_adapter_bedrock.utils.list_projection import ListProjection
 
 
 def preprocess_messages_decorator(
-    on_messages: Callable[[List[Message]], ListProjection[Message]]
+    on_messages: Callable[[List[Message]], ListProjection[Message]],
 ) -> ChatCompletionTransformer:
     return lambda adapter: PreprocessMessagesDecorator(
         on_messages=on_messages, adapter=adapter
@@ -31,7 +31,9 @@ class PreprocessMessagesDecorator(ChatCompletionDecorator):
     ) -> None:
         new_messages = self.on_messages(messages)
         await self.adapter.chat(consumer, params, new_messages.raw_list)
-        if discarded_messages := consumer.get_discarded_messages() is not None:
+        if (
+            discarded_messages := consumer.get_discarded_messages()
+        ) is not None:
             discarded_messages = list(
                 new_messages.to_original_indices(discarded_messages)
             )

--- a/aidial_adapter_bedrock/utils/list_projection.py
+++ b/aidial_adapter_bedrock/utils/list_projection.py
@@ -20,17 +20,13 @@ class ListProjection(Generic[_T]):
     def raw_list(self) -> List[_T]:
         return [msg for msg, _ in self.list]
 
-    def to_original_indices(self, idx: int | Iterable[int]) -> Set[int]:
+    def to_original_indices(self, indices: Iterable[int]) -> Set[int]:
         return {
             orig_index
-            for index in _to_set(idx)
+            for index in indices
             for orig_index in self.list[index][1]
         }
 
-    def append(self, elem: _T, idx: int | Iterable[int]) -> Self:
-        self.list.append((elem, _to_set(idx)))
+    def append(self, elem: _T, idx: int) -> Self:
+        self.list.append((elem, {idx}))
         return self
-
-
-def _to_set(idx: int | Iterable[int]) -> Set[int]:
-    return {idx} if isinstance(idx, int) else set(idx)

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -801,3 +801,14 @@ async def test_tool_response(
 
     for temp in test.city_temps:
         assert str(temp) in response.content
+
+
+@pytest.mark.parametrize("deployment", deployments, ids=display_deployment)
+async def test_max_prompt_tokens(chat: Chat):
+    response = await chat(
+        max_tokens=1,
+        messages=[user("test")],
+        extra_body={"max_prompt_tokens": 200},
+    )
+    statistics = response.response.dict().get("statistics", {})
+    assert statistics.get("discarded_messages") == []


### PR DESCRIPTION
Resolves #324 

The issue was that a **boolean** value was passed to the method `to_original_indices(self, idx: int | Iterable[int])` which expects **int(s)**.

Pyright didn't highlight the issue because `isinstance(True, int) == True` in Python.

The issue is fixed by restricting the signature of the ListProjection class.