### PR TITLE
fix: Converse API: support attachments in the default tokenizer

### DIFF
--- a/aidial_adapter_bedrock/llm/converse/adapter.py
+++ b/aidial_adapter_bedrock/llm/converse/adapter.py
@@ -1,5 +1,5 @@
 from logging import DEBUG
-from typing import Any, Awaitable, Callable, List, Tuple, Type
+from typing import Awaitable, Callable, List, Tuple, Type
 
 from aidial_sdk.chat_completion import Message as DialMessage
 
@@ -15,6 +15,9 @@ from aidial_adapter_bedrock.llm.consumer import Consumer
 from aidial_adapter_bedrock.llm.converse.configuration import (
     ConverseAPIConfiguration,
 )
+from aidial_adapter_bedrock.llm.converse.default_tokenizer import (
+    default_converse_tokenizer_factory,
+)
 from aidial_adapter_bedrock.llm.converse.input import (
     extract_converse_system_prompt,
     to_converse_messages,
@@ -28,7 +31,7 @@ from aidial_adapter_bedrock.llm.converse.types import (
     ConverseDeployment,
     ConverseDocumentType,
     ConverseImageType,
-    ConverseMessage,
+    ConverseMessages,
     ConverseRequestWrapper,
     ConverseTools,
     GuardrailConfig,
@@ -46,8 +49,6 @@ from aidial_adapter_bedrock.utils.list import omit_by_indices
 from aidial_adapter_bedrock.utils.list_projection import ListProjection
 from aidial_adapter_bedrock.utils.log_config import bedrock_logger as log
 
-ConverseMessages = List[Tuple[ConverseMessage, Any]]
-
 
 class ConverseAdapter(ChatCompletionAdapter):
     deployment: str
@@ -60,7 +61,8 @@ class ConverseAdapter(ChatCompletionAdapter):
     input_tokenizer_factory: Callable[
         [ConverseDeployment, ConverseRequestWrapper],
         Callable[[ConverseMessages], Awaitable[int]],
-    ]
+    ] = default_converse_tokenizer_factory
+
     support_tools: bool
     partitioner: Callable[[ConverseMessages], List[int]] = (
         turn_based_partitioner

--- a/aidial_adapter_bedrock/llm/converse/default_tokenizer.py
+++ b/aidial_adapter_bedrock/llm/converse/default_tokenizer.py
@@ -1,8 +1,9 @@
 import json
+from typing import Any
 
-from aidial_adapter_bedrock.llm.converse.adapter import ConverseMessages
 from aidial_adapter_bedrock.llm.converse.types import (
     ConverseDeployment,
+    ConverseMessages,
     ConverseRequestWrapper,
 )
 from aidial_adapter_bedrock.llm.tokenize import default_tokenize_string
@@ -11,12 +12,15 @@ from aidial_adapter_bedrock.llm.tokenize import default_tokenize_string
 def default_converse_tokenizer_factory(
     deployment: ConverseDeployment, params: ConverseRequestWrapper
 ):
-    tool_tokens = default_tokenize_string(json.dumps(params.toolConfig))
-    system_tokens = default_tokenize_string(json.dumps(params.system))
+    def _to_string(obj: Any) -> str:
+        return json.dumps(obj, default=str)
+
+    tool_tokens = default_tokenize_string(_to_string(params.toolConfig))
+    system_tokens = default_tokenize_string(_to_string(params.system))
 
     async def tokenizer(msg_items: ConverseMessages) -> int:
         tokens = sum(
-            default_tokenize_string(json.dumps(msg_item[0]))
+            default_tokenize_string(_to_string(msg_item[0]))
             for msg_item in msg_items
         )
         return tokens + tool_tokens + system_tokens

--- a/aidial_adapter_bedrock/llm/converse/types.py
+++ b/aidial_adapter_bedrock/llm/converse/types.py
@@ -5,7 +5,7 @@ https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedro
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Literal, Required, TypedDict, Union
+from typing import Any, List, Literal, Required, Tuple, TypedDict, Union
 
 from aidial_adapter_bedrock.utils.json import remove_nones
 from aidial_adapter_bedrock.utils.list_projection import ListProjection
@@ -201,3 +201,6 @@ class ConverseDocumentType(str, Enum):
     @classmethod
     def all(cls) -> list["ConverseDocumentType"]:
         return list(cls)
+
+
+ConverseMessages = List[Tuple[ConverseMessage, Any]]

--- a/tests/unit_tests/converse/test_converse_adapter.py
+++ b/tests/unit_tests/converse/test_converse_adapter.py
@@ -119,6 +119,17 @@ class TestCase:
     expected_output: ConverseRequestWrapper | None = None
     expected_error: ExpectedException | None = None
 
+    async def get_converse_adapter(self):
+        client = await Bedrock.acreate(CloudUpstreamConfig(region="us-east-1"))
+        return ConverseAdapter(
+            deployment="test",
+            bedrock=client,
+            support_tools=True,
+            storage=None,
+            supported_image_types=self.supported_image_types,
+            supported_document_types=self.supported_document_types,
+        )
+
 
 def _create_document_test_cases() -> List[TestCase]:
     return [
@@ -670,27 +681,18 @@ TEST_CASES = [
     "test_case", TEST_CASES, ids=lambda test_case: test_case.name
 )
 async def test_converse_adapter(test_case: TestCase):
-    adapter = ConverseAdapter(
-        deployment="test",
-        bedrock=await Bedrock.acreate(CloudUpstreamConfig(region="us-east-1")),
-        support_tools=True,
-        storage=None,
-        supported_image_types=test_case.supported_image_types,
-        supported_document_types=test_case.supported_document_types,
-    )
+    adapter = await test_case.get_converse_adapter()
     construct_coro = adapter.construct_converse_params(
-        messages=test_case.messages,
-        params=test_case.params,
+        messages=test_case.messages, params=test_case.params
     )
 
-    if test_case.expected_error is not None:
-        with pytest.raises(test_case.expected_error.type) as exc_info:
-            converse_request = await construct_coro
-        error_message = getattr(exc_info.value, "message", None) or getattr(
-            exc_info.value, "error_message", None
+    if (err := test_case.expected_error) is not None:
+        with pytest.raises(err.type) as e:
+            await construct_coro
+        message = getattr(e.value, "message", None) or getattr(
+            e.value, "error_message", None
         )
-        assert isinstance(error_message, str)
-        assert error_message == test_case.expected_error.message
+        assert message == err.message
     else:
         converse_request = await construct_coro
         assert converse_request == test_case.expected_output
@@ -700,27 +702,19 @@ async def test_converse_adapter(test_case: TestCase):
     "test_case", TEST_CASES, ids=lambda test_case: test_case.name
 )
 async def test_converse_prompt_tokenizer(test_case: TestCase):
-    adapter = ConverseAdapter(
-        deployment="test",
-        bedrock=await Bedrock.acreate(CloudUpstreamConfig(region="us-east-1")),
-        support_tools=True,
-        storage=None,
-        supported_image_types=test_case.supported_image_types,
-        supported_document_types=test_case.supported_document_types,
-    )
+    adapter = await test_case.get_converse_adapter()
     construct_coro = adapter.count_prompt_tokens(
-        messages=test_case.messages,
-        params=test_case.params,
+        messages=test_case.messages, params=test_case.params
     )
 
-    if test_case.expected_error is not None:
-        with pytest.raises(test_case.expected_error.type) as exc_info:
+    if (err := test_case.expected_error) is not None:
+        with pytest.raises(err.type) as e:
             await construct_coro
-        error_message = getattr(exc_info.value, "message", None) or getattr(
-            exc_info.value, "error_message", None
+        message = getattr(e.value, "message", None) or getattr(
+            e.value, "error_message", None
         )
-        assert isinstance(error_message, str)
-        assert error_message == test_case.expected_error.message
+        assert message == err.message
+
     else:
         prompt_tokens = await construct_coro
         assert prompt_tokens > 0

--- a/tests/unit_tests/converse/test_converse_adapter.py
+++ b/tests/unit_tests/converse/test_converse_adapter.py
@@ -59,13 +59,6 @@ from tests.integration_tests.constants import (
 )
 
 
-async def _input_tokenizer_factory(_deployment, _params):
-    async def _test_tokenizer(_messages) -> int:
-        return 100
-
-    return _test_tokenizer
-
-
 @dataclass(frozen=True)
 class UndefinedValue(str):
     """Sentinel object for values that should be ignored in comparisons."""
@@ -680,8 +673,6 @@ async def test_converse_adapter(test_case: TestCase):
     adapter = ConverseAdapter(
         deployment="test",
         bedrock=await Bedrock.acreate(CloudUpstreamConfig(region="us-east-1")),
-        tokenize_text=lambda x: len(x),
-        input_tokenizer_factory=_input_tokenizer_factory,  # type: ignore
         support_tools=True,
         storage=None,
         supported_image_types=test_case.supported_image_types,
@@ -695,14 +686,41 @@ async def test_converse_adapter(test_case: TestCase):
     if test_case.expected_error is not None:
         with pytest.raises(test_case.expected_error.type) as exc_info:
             converse_request = await construct_coro
-        assert hasattr(exc_info.value, "message") or hasattr(
-            exc_info.value, "error_message"
-        )
         error_message = getattr(exc_info.value, "message", None) or getattr(
-            exc_info.value, "error_message"
+            exc_info.value, "error_message", None
         )
         assert isinstance(error_message, str)
         assert error_message == test_case.expected_error.message
     else:
         converse_request = await construct_coro
         assert converse_request == test_case.expected_output
+
+
+@pytest.mark.parametrize(
+    "test_case", TEST_CASES, ids=lambda test_case: test_case.name
+)
+async def test_converse_prompt_tokenizer(test_case: TestCase):
+    adapter = ConverseAdapter(
+        deployment="test",
+        bedrock=await Bedrock.acreate(CloudUpstreamConfig(region="us-east-1")),
+        support_tools=True,
+        storage=None,
+        supported_image_types=test_case.supported_image_types,
+        supported_document_types=test_case.supported_document_types,
+    )
+    construct_coro = adapter.count_prompt_tokens(
+        messages=test_case.messages,
+        params=test_case.params,
+    )
+
+    if test_case.expected_error is not None:
+        with pytest.raises(test_case.expected_error.type) as exc_info:
+            await construct_coro
+        error_message = getattr(exc_info.value, "message", None) or getattr(
+            exc_info.value, "error_message", None
+        )
+        assert isinstance(error_message, str)
+        assert error_message == test_case.expected_error.message
+    else:
+        prompt_tokens = await construct_coro
+        assert prompt_tokens > 0


### PR DESCRIPTION
Consider a chat completion request to a deployment based on the Converse API _(e.g. any Llama model)_ that 
* includes documents/images,
* has `max_prompt_tokens` parameter

`max_prompt_tokens` parameter triggers the prompt truncation algorithm, which in turn triggers the tokenisation of the request. The default tokeniser is trying to convert the entire request to JSON and count the number of symbols as an approximation of the prompt token count.

**Before the fix**: a document is stored in the Converse request as `bytes`, which makes the tokenizer fail with the error:

```
TypeError: Object of type bytes is not JSON serializable
```

**After the fix**: the bytes in the Converse request are properly handled, and the error isn't thrown.