### PR TITLE
fix: relax validation that requires tool definitions

### DIFF
--- a/aidial_adapter_bedrock/llm/converse/adapter.py
+++ b/aidial_adapter_bedrock/llm/converse/adapter.py
@@ -118,11 +118,7 @@ class ConverseAdapter(ChatCompletionAdapter):
     def get_tool_config(self, params: ModelParameters) -> ConverseTools | None:
         if params.tool_config and not self.support_tools:
             raise ValidationError("Tools are not supported")
-        return (
-            to_converse_tools(params.tool_config)
-            if params.tool_config
-            else None
-        )
+        return to_converse_tools(params.tool_config)
 
     async def construct_converse_params(
         self,

--- a/aidial_adapter_bedrock/llm/converse/input.py
+++ b/aidial_adapter_bedrock/llm/converse/input.py
@@ -72,7 +72,10 @@ def to_converse_role(role: DialRole) -> ConverseRole:
             assert_never(role)
 
 
-def to_converse_tools(tools_config: ToolsConfig) -> ConverseTools:
+def to_converse_tools(tools_config: ToolsConfig | None) -> ConverseTools | None:
+    if tools_config is None or not tools_config.tools:
+        return None
+
     tools: list[ConverseToolSpec | ConverseCachePointPart] = []
     for tool in tools_config.tools:
         function = tool.function

--- a/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
@@ -119,8 +119,8 @@ from aidial_adapter_bedrock.llm.model.claude.v3.tokenizer import (
     tokenize_text,
 )
 from aidial_adapter_bedrock.llm.model.claude.v3.tools import (
+    function_to_tool_messages,
     process_tools_block,
-    process_with_tools,
 )
 from aidial_adapter_bedrock.llm.model.conf import CLAUDE_DEFAULT_MAX_TOKENS
 from aidial_adapter_bedrock.llm.tools.tools_config import ToolsMode
@@ -229,7 +229,9 @@ class Adapter(ChatCompletionAdapter):
 
         tools = omit
         tool_choice: ToolChoice | Omit = omit
-        if (tool_config := params.tool_config) is not None:
+        if (
+            tool_config := params.tool_config
+        ) is not None and tool_config.tools:
             tools = [to_claude_tool_config(tool) for tool in tool_config.tools]
 
             match tool_config.tool_choice:
@@ -251,8 +253,7 @@ class Adapter(ChatCompletionAdapter):
             # to one in the adapter itself for the functions mode.
 
         parsed_messages = [
-            process_with_tools(parse_dial_message(m), params.tools_mode)
-            for m in messages
+            function_to_tool_messages(parse_dial_message(m)) for m in messages
         ]
 
         system_prompt, claude_messages = await to_claude_messages(

--- a/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
@@ -3,7 +3,6 @@ from logging import DEBUG
 from typing import List, Optional, Tuple, Type, assert_never
 
 from aidial_sdk.chat_completion import Message as DialMessage
-from aidial_sdk.chat_completion import ToolChoice as DialToolChoice
 from anthropic import AsyncAnthropic, AsyncAnthropicBedrock, Omit, omit
 from anthropic._resource import AsyncAPIResource
 from anthropic.lib.streaming import (
@@ -55,11 +54,6 @@ from anthropic.types.beta import (
 )
 from anthropic.types.beta import BetaThinkingBlock as ThinkingBlock
 from anthropic.types.beta import BetaThinkingConfigParam as ThinkingConfigParam
-from anthropic.types.beta import BetaToolChoiceAnyParam as ToolChoiceAnyParam
-from anthropic.types.beta import BetaToolChoiceAutoParam as ToolChoiceAutoParam
-from anthropic.types.beta import BetaToolChoiceNoneParam as ToolChoiceNoneParam
-from anthropic.types.beta import BetaToolChoiceParam as ToolChoice
-from anthropic.types.beta import BetaToolChoiceToolParam as ToolChoiceToolParam
 from anthropic.types.beta import BetaToolUseBlock as ToolUseBlock
 from anthropic.types.beta import (
     BetaWebFetchToolResultBlock as WebFetchToolResultBlock,
@@ -227,30 +221,7 @@ class Adapter(ChatCompletionAdapter):
         if len(messages) == 0:
             raise ValidationError("List of messages must not be empty")
 
-        tools = omit
-        tool_choice: ToolChoice | Omit = omit
-        if (
-            tool_config := params.tool_config
-        ) is not None and tool_config.tools:
-            tools = [to_claude_tool_config(tool) for tool in tool_config.tools]
-
-            match tool_config.tool_choice:
-                case DialToolChoice(function=function):
-                    tool_choice = ToolChoiceToolParam(
-                        type="tool", name=function.name
-                    )
-                case "required":
-                    tool_choice = ToolChoiceAnyParam(type="any")
-                case "auto":
-                    tool_choice = ToolChoiceAutoParam(type="auto")
-                case "none":
-                    tool_choice = ToolChoiceNoneParam(type="none")
-                case _:
-                    assert_never(tool_config.tool_choice)
-
-            # NOTE tool_choice.disable_parallel_tool_use=True option isn't supported
-            # by older Claude3 versions, so we limit the number of generated function calls
-            # to one in the adapter itself for the functions mode.
+        tools_config = to_claude_tool_config(params.tool_config)
 
         parsed_messages = [
             function_to_tool_messages(parse_dial_message(m)) for m in messages
@@ -286,8 +257,8 @@ class Adapter(ChatCompletionAdapter):
             system=system_prompt or omit,
             temperature=temperature,
             top_p=params.top_p or omit,
-            tools=tools,
-            tool_choice=tool_choice,
+            tools=(tools_config and tools_config.tools) or omit,
+            tool_choice=(tools_config and tools_config.tool_choice) or omit,
             thinking=thinking,
             betas=configuration.betas or omit,
         )

--- a/aidial_adapter_bedrock/llm/model/claude/v3/converters.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/converters.py
@@ -1,6 +1,7 @@
 from typing import Iterable, List, Literal, Optional, Set, Tuple, assert_never
 
 from aidial_sdk.chat_completion import FinishReason, Tool
+from aidial_sdk.chat_completion import ToolChoice as DialToolChoice
 from anthropic.types.beta import (
     BetaCacheControlEphemeralParam as CacheControlEphemeralParam,
 )
@@ -12,8 +13,14 @@ from anthropic.types.beta import (
 )
 from anthropic.types.beta import BetaStopReason as ClaudeStopReason
 from anthropic.types.beta import BetaTextBlockParam as TextBlockParam
+from anthropic.types.beta import BetaToolChoiceAnyParam as ToolChoiceAnyParam
+from anthropic.types.beta import BetaToolChoiceAutoParam as ToolChoiceAutoParam
+from anthropic.types.beta import BetaToolChoiceNoneParam as ToolChoiceNoneParam
+from anthropic.types.beta import BetaToolChoiceParam as ToolChoice
+from anthropic.types.beta import BetaToolChoiceToolParam as ToolChoiceToolParam
 from anthropic.types.beta import BetaToolParam as ToolParam
 from anthropic.types.beta import BetaUsage as Usage
+from pydantic import BaseModel
 
 from aidial_adapter_bedrock.dial_api.token_usage import TokenUsage
 from aidial_adapter_bedrock.llm.errors import ValidationError
@@ -37,7 +44,7 @@ from aidial_adapter_bedrock.llm.model.claude.v3.config import Configuration
 from aidial_adapter_bedrock.llm.model.claude.v3.state import (
     get_message_content_from_state,
 )
-from aidial_adapter_bedrock.llm.tools.tools_config import ToolsMode
+from aidial_adapter_bedrock.llm.tools.tools_config import ToolsConfig, ToolsMode
 from aidial_adapter_bedrock.utils.list import group_by
 from aidial_adapter_bedrock.utils.list_projection import ListProjection
 
@@ -217,7 +224,7 @@ def to_dial_usage(usage: Usage) -> TokenUsage:
     )
 
 
-def to_claude_tool_config(tool: Tool) -> ToolParam:
+def _to_claude_tool(tool: Tool) -> ToolParam:
     function = tool.function
     tool_param = ToolParam(
         input_schema=function.parameters
@@ -230,3 +237,39 @@ def to_claude_tool_config(tool: Tool) -> ToolParam:
         tool_param["cache_control"] = _claude_cache_breakpoint
 
     return tool_param
+
+
+def _to_claude_tool_choice(
+    tool_choice: Literal["auto", "none", "required"] | DialToolChoice,
+) -> ToolChoice:
+    # NOTE tool_choice.disable_parallel_tool_use=True option isn't supported
+    # by older Claude3 versions, so we limit the number of generated function calls
+    # to one in the adapter itself for the functions mode.
+
+    match tool_choice:
+        case DialToolChoice(function=function):
+            return ToolChoiceToolParam(type="tool", name=function.name)
+        case "required":
+            return ToolChoiceAnyParam(type="any")
+        case "auto":
+            return ToolChoiceAutoParam(type="auto")
+        case "none":
+            return ToolChoiceNoneParam(type="none")
+        case _:
+            assert_never(tool_choice)
+
+
+class ClaudeToolsConfig(BaseModel):
+    tools: List[ToolParam]
+    tool_choice: ToolChoice
+
+
+def to_claude_tool_config(
+    tools_config: ToolsConfig | None,
+) -> ClaudeToolsConfig | None:
+    if tools_config is None or not tools_config.tools:
+        return None
+
+    tools = [_to_claude_tool(tool) for tool in tools_config.tools]
+    tool_choice = _to_claude_tool_choice(tools_config.tool_choice)
+    return ClaudeToolsConfig(tools=tools, tool_choice=tool_choice)

--- a/aidial_adapter_bedrock/llm/model/claude/v3/tools.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/tools.py
@@ -66,56 +66,33 @@ def process_tools_block(
             assert_never(tools_mode)
 
 
-def process_with_tools(
-    message: BaseMessage | ToolMessage, tools_mode: ToolsMode | None
+def function_to_tool_messages(
+    message: BaseMessage | ToolMessage,
 ) -> BaseMessage | HumanToolResultMessage | AIToolCallMessage:
-    """
-    1. Validates, that no Functions or Tools messages are used without config
-    2. Validates, that client don't use Functions messages with tools config
-    3. Validates, that client don't use Tools messages with functions config
-    4. Convert Functions messages to Tools messages (Claude supports only Tools).
-        For tool id we just use function name
-    """
-    if tools_mode is None:
-        if not isinstance(message, BaseMessage):
-            raise ValidationError(
-                "You cannot use messages with functions or tools without config. Please change your messages."
-            )
-        return message
-    elif tools_mode == ToolsMode.TOOLS:
-        if isinstance(
-            message, (HumanFunctionResultMessage, AIFunctionCallMessage)
+    match message:
+        case (
+            SystemMessage()
+            | HumanRegularMessage()
+            | AIRegularMessage()
+            | HumanToolResultMessage()
+            | AIToolCallMessage()
         ):
-            raise ValidationError(
-                "You cannot use function messages with tools config."
+            return message
+        case AIFunctionCallMessage():
+            return AIToolCallMessage(
+                content=message.content,
+                calls=[
+                    ToolCall(
+                        index=None,
+                        id=message.call.name,
+                        type="function",
+                        function=message.call,
+                    )
+                ],
             )
-        return message
-    elif tools_mode == ToolsMode.FUNCTIONS:
-        match message:
-            case SystemMessage() | HumanRegularMessage() | AIRegularMessage():
-                return message
-            case HumanToolResultMessage() | AIToolCallMessage():
-                raise ValidationError(
-                    "You cannot use tools messages with functions config."
-                )
-            case AIFunctionCallMessage():
-                return AIToolCallMessage(
-                    content=message.content,
-                    calls=[
-                        ToolCall(
-                            index=None,
-                            id=message.call.name,
-                            type="function",
-                            function=message.call,
-                        )
-                    ],
-                )
-            case HumanFunctionResultMessage():
-                return HumanToolResultMessage(
-                    id=message.name, content=message.content
-                )
-            case _:
-                assert_never(message)
-
-    else:
-        assert_never(tools_mode)
+        case HumanFunctionResultMessage():
+            return HumanToolResultMessage(
+                id=message.name, content=message.content
+            )
+        case _:
+            assert_never(message)

--- a/aidial_adapter_bedrock/llm/model/llama/v3.py
+++ b/aidial_adapter_bedrock/llm/model/llama/v3.py
@@ -10,6 +10,6 @@ class ConverseAdapterWithStreamingEmulation(ConverseAdapter):
     """
 
     def is_stream(self, params: ModelParameters) -> bool:
-        if self.get_tool_config(params):
+        if params.tool_config is not None:
             return False
         return params.stream

--- a/aidial_adapter_bedrock/llm/tools/tools_config.py
+++ b/aidial_adapter_bedrock/llm/tools/tools_config.py
@@ -16,6 +16,7 @@ from aidial_sdk.chat_completion.request import (
 from pydantic import BaseModel
 
 from aidial_adapter_bedrock.llm.errors import ValidationError
+from aidial_adapter_bedrock.utils.log_config import app_logger as log
 
 
 class ToolsMode(Enum):
@@ -32,20 +33,15 @@ class ToolsConfig(BaseModel):
     List of functions/tools.
     """
 
+    tools_mode: ToolsMode
+
     tool_choice: Literal["auto", "none", "required"] | ToolChoice
 
-    tool_ids: Dict[str, str] | None
+    tool_ids: Dict[str, str]
     """
     Mapping from tool call IDs to corresponding tool names.
-    None means that functions are used, not tools.
+    Empty when there are no tool calls in the messages.
     """
-
-    @property
-    def tools_mode(self) -> ToolsMode:
-        if self.tool_ids is not None:
-            return ToolsMode.TOOLS
-        else:
-            return ToolsMode.FUNCTIONS
 
     def not_supported(self) -> None:
         if self.tools:
@@ -55,9 +51,6 @@ class ToolsConfig(BaseModel):
                 raise ValidationError("The functions aren't supported")
 
     def create_fresh_tool_call_id(self, tool_name: str) -> str:
-        if self.tool_ids is None:
-            raise ValidationError("Function are used, but requested tool id")
-
         idx = 1
         while True:
             id = f"{tool_name}_{idx}"
@@ -67,9 +60,6 @@ class ToolsConfig(BaseModel):
             idx += 1
 
     def get_tool_name(self, tool_call_id: str) -> str:
-        if self.tool_ids is None:
-            raise ValidationError("Function are used, but requested tool name")
-
         tool_name = self.tool_ids.get(tool_call_id)
         if tool_name is None:
             raise ValidationError(f"Tool call ID not found: {self.tool_ids}")
@@ -94,31 +84,38 @@ class ToolsConfig(BaseModel):
         else:
             return tool
 
+    @staticmethod
+    def _get_tools_from_functions(
+        tools: List[Function] | List[Tool | StaticTool],
+    ) -> List[Tool]:
+        return [ToolsConfig._get_tool_from_function(tool) for tool in tools]
+
     @classmethod
     def from_request(cls, request: AzureChatCompletionRequest) -> Self | None:
         validate_messages(request)
 
+        tool_ids = _collect_tool_ids(request.messages)
+
         if request.functions is not None:
-            tools = [
-                ToolsConfig._get_tool_from_function(tool)
-                for tool in request.functions
-            ]
-            tool_choice = ToolsConfig._function_call_to_tool_choice(
+            tools_mode = ToolsMode.FUNCTIONS
+            tools = cls._get_tools_from_functions(request.functions)
+            tool_choice = cls._function_call_to_tool_choice(
                 request.function_call
             )
-            tool_ids = None
         elif request.tools is not None:
-            tools = [
-                ToolsConfig._get_tool_from_function(tool)
-                for tool in request.tools
-            ]
+            tools_mode = ToolsMode.TOOLS
+            tools = cls._get_tools_from_functions(request.tools)
             tool_choice = request.tool_choice
-            tool_ids = _collect_tool_ids(request.messages)
+        elif tool_ids:
+            tools_mode = ToolsMode.TOOLS
+            tools = []
+            tool_choice = None
         else:
             return None
 
         return cls(
             tools=tools,
+            tools_mode=tools_mode,
             tool_choice=tool_choice or "auto",
             tool_ids=tool_ids,
         )
@@ -131,29 +128,43 @@ def validate_messages(request: AzureChatCompletionRequest) -> None:
     if decl_functions and decl_tools:
         raise ValidationError("Both functions and tools are not allowed")
 
-    for message in request.messages:
-        if message.role == Role.ASSISTANT:
-            use_tools = message.tool_calls is not None
-            if use_tools and not decl_tools:
-                raise ValidationError(
-                    "Assistant message uses tools, but tools are not declared"
-                )
+    def warn(msg: str):
+        log.warning(
+            f"The request is incomplete: {msg}. The model may misbehave."
+        )
 
-            use_functions = message.function_call is not None
-            if use_functions and not decl_functions:
-                raise ValidationError(
-                    "Assistant message uses functions, but functions are not declared"
-                )
-        if message.role == Role.FUNCTION:
-            if not decl_functions:
-                raise ValidationError(
-                    "Function message is used, but functions are not declared"
-                )
-        if message.role == Role.TOOL:
-            if not decl_tools:
-                raise ValidationError(
-                    "Tool message is used, but tools are not declared"
-                )
+    tool_defs_are_missing = (
+        "the request is missing tool definitions in the 'tools' field"
+    )
+    func_defs_are_missing = (
+        "the request is missing function definitions in the 'functions' field"
+    )
+
+    for idx, message in enumerate(request.messages):
+        if (
+            message.role == Role.ASSISTANT
+            and message.tool_calls is not None
+            and not decl_tools
+        ):
+            warn(
+                f"'messages[{idx}]' is an Assistant message with a tool call, but {tool_defs_are_missing}"
+            )
+        if (
+            message.role == Role.ASSISTANT
+            and message.function_call is not None
+            and not decl_functions
+        ):
+            warn(
+                f"'messages[{idx}]' is an Assistant messages with a function call, but {func_defs_are_missing}"
+            )
+        if message.role == Role.FUNCTION and not decl_functions:
+            warn(
+                f"'messages[{idx}]' is a Function message, but {func_defs_are_missing}"
+            )
+        if message.role == Role.TOOL and not decl_tools:
+            warn(
+                f"'messages[{idx}]' is a Tool message, but {tool_defs_are_missing}"
+            )
 
 
 def _collect_tool_ids(messages: List[Message]) -> Dict[str, str]:

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -679,7 +679,7 @@ async def test_forced_tool_choice(chat: Chat):
     )
 
     tool_calls = response.tool_calls
-    assert tool_calls is not None
+    assert tool_calls is not None, "No tool calls were made"
     assert len(tool_calls) == 1
 
     function = tool_calls[0].function
@@ -815,7 +815,7 @@ async def test_tool_call(
     )
 
     tool_calls = response.tool_calls
-    assert tool_calls is not None
+    assert tool_calls is not None, "No tool calls were made"
 
     expected_calls = test.targets if supports_parallel_tool_calls(origin) else 1
 

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -699,6 +699,61 @@ async def test_forced_tool_choice(chat: Chat):
     select(pred(supports_tools), deployments),
     ids=display_deployment,
 )
+async def test_tool_calls_without_tool_definitions(
+    deployment: D, optimized_latency: bool, chat: Chat
+):
+    origin = deployment.origin
+    if origin == D.ANTHROPIC_CLAUDE_V3_SONNET:
+        exc = ExpectedException(
+            type=BadRequestError,
+            message="Requests which include `tool_use` or `tool_result` blocks must define tools.",
+            status_code=400,
+        )
+    elif is_claude(origin) and not optimized_latency:
+        exc = None
+    else:
+        # All Converse API based models fail with the validation error
+        exc = ExpectedException(
+            type=BadRequestError,
+            message="The toolConfig field must be defined when using toolUse and toolResult content blocks",
+            status_code=400,
+        )
+
+    async def _run():
+        return await chat(
+            messages=[
+                user("what time is it?"),
+                ai_tools(
+                    [
+                        {
+                            "type": "function",
+                            "id": "tool-call-id1",
+                            "function": {
+                                "name": "get_current_time",
+                                "arguments": "{}",
+                            },
+                        }
+                    ]
+                ),
+                tool_response(id="tool-call-id1", content="01:22 AM"),
+                ai("It's 01:22 AM"),
+                user("Now compute (2+3). Reply with a single digit"),
+            ],
+        )
+
+    if exc:
+        async with expected_exception(exc):
+            await _run()
+    else:
+        response = await _run()
+        assert "5" in response.content
+
+
+@pytest.mark.parametrize(
+    "deployment",
+    select(pred(supports_tools), deployments),
+    ids=display_deployment,
+)
 @pytest.mark.parametrize(
     "test", [ToolCallTest(1), ToolCallTest(2)], ids=lambda x: x.get_id()
 )

--- a/tests/integration_tests/test_claude_thinking.py
+++ b/tests/integration_tests/test_claude_thinking.py
@@ -145,7 +145,7 @@ async def test_claude_thinking_with_function_calling(
     messages.append(bot_message1.dict())  # type: ignore
 
     tool_calls = bot_message1.tool_calls
-    assert tool_calls is not None
+    assert tool_calls is not None, "No tool calls were made"
     assert len(tool_calls) == len(cities)
 
     for tool_call, temp in zip(tool_calls, temps):

--- a/tests/unit_tests/converse/test_converse_adapter.py
+++ b/tests/unit_tests/converse/test_converse_adapter.py
@@ -50,7 +50,7 @@ from aidial_adapter_bedrock.llm.converse.types import (
     InferenceConfig,
 )
 from aidial_adapter_bedrock.llm.errors import UserError, ValidationError
-from aidial_adapter_bedrock.llm.tools.tools_config import ToolsConfig
+from aidial_adapter_bedrock.llm.tools.tools_config import ToolsConfig, ToolsMode
 from aidial_adapter_bedrock.upstream_config import CloudUpstreamConfig
 from aidial_adapter_bedrock.utils.list_projection import ListProjection
 from tests.integration_tests.constants import (
@@ -446,7 +446,8 @@ TEST_CASES = [
                     )
                 ],
                 tool_choice="required",
-                tool_ids=None,
+                tools_mode=ToolsMode.TOOLS,
+                tool_ids={},
             )
         ),
         expected_output=ConverseRequestWrapper(
@@ -528,7 +529,8 @@ TEST_CASES = [
                 tool_choice=ToolChoice(
                     type="function", function=FunctionChoice(name="get_weather")
                 ),
-                tool_ids=None,
+                tools_mode=ToolsMode.TOOLS,
+                tool_ids={},
             )
         ),
         expected_output=ConverseRequestWrapper(

--- a/tests/unit_tests/test_claude3_truncate_prompt.py
+++ b/tests/unit_tests/test_claude3_truncate_prompt.py
@@ -13,7 +13,7 @@ from aidial_adapter_bedrock.llm.chat_model import ChatCompletionAdapter
 from aidial_adapter_bedrock.llm.model.claude.v3.adapter import (
     Adapter as Claude_V3,
 )
-from aidial_adapter_bedrock.llm.tools.tools_config import ToolsConfig
+from aidial_adapter_bedrock.llm.tools.tools_config import ToolsConfig, ToolsMode
 from aidial_adapter_bedrock.llm.truncate_prompt import DiscardedMessages
 from aidial_adapter_bedrock.upstream_config import CloudUpstreamConfig
 from tests.utils.messages import ai, sys, user, user_with_image
@@ -59,6 +59,7 @@ _TOOL_CONFIG = ToolsConfig(
     tools=[Tool(type="function", function=Function(name="function"))],
     tool_choice="auto",
     tool_ids={},
+    tools_mode=ToolsMode.TOOLS,
 )
 
 _PER_MESSAGE_TOKENS = 5


### PR DESCRIPTION
Analogous to https://github.com/epam/ai-dial-adapter-vertexai/pull/322

Claude models can process the invalid requests just fine, but all models based on the Converse API fail with the error:

> The toolConfig field must be defined when using toolUse and toolResult content blocks