### PR TITLE
fix!: disable retries in HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ Copy `.env.example` to `.env` and customize it for your environment:
 |WEB_CONCURRENCY|1|Number of workers for the server|
 |COMPATIBILITY_MAPPING|{}|A JSON dictionary that maps Bedrock deployments that **aren't supported** by the Adapter to the Bedrock deployments that **are supported** by the Adapter _(see the [Supported models](#supported-models)_ section). Find more details in the [compatibility mode](#compatibility-mode) section.|
 |CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request.<br>**:warning: Using the variable is discouraged**.<br>Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
+|BOTOCORE_MAX_RETRY_ATTEMPTS|0|How many times to retry chat model requests made via the Bedrock API or Converse API when the provider returns a retriable error|
+|ANTHROPIC_MAX_RETRY_ATTEMPTS|0|How many times to retry Anthropic chat model requests when the provider returns a retriable error|
 
 ### Resource limits
 

--- a/aidial_adapter_bedrock/bedrock.py
+++ b/aidial_adapter_bedrock/bedrock.py
@@ -75,6 +75,7 @@ async def create_anthropic_client(
         anthropic_client = AsyncAnthropic(
             api_key=upstream_config.api_key,
             http_client=http_client,
+            max_retries=0,
         )
         return (None, anthropic_client)
     else:
@@ -85,6 +86,7 @@ async def create_anthropic_client(
             aws_secret_key=creds.aws_secret_access_key,
             aws_session_token=creds.aws_session_token,
             http_client=http_client,
+            max_retries=0,
         )
         return expiration, anthropic_client
 
@@ -99,7 +101,11 @@ async def create_boto_client(
     config = botocore.client.Config(  # type: ignore
         # The max number of connections to the same upstream that are persisted (saved to a connection pool).
         # Greater number of connections *don't block* each other.
-        max_pool_connections=BOTOCORE_CLIENT_MAX_POOL_CONNECTIONS
+        max_pool_connections=BOTOCORE_CLIENT_MAX_POOL_CONNECTIONS,
+        retries={
+            "mode": "standard",
+            "total_max_attempts": get_env_int("AWS_MAX_ATTEMPTS", 1),
+        },
     )
 
     # NOTE: Session isn't thread-safe, but client is.

--- a/aidial_adapter_bedrock/bedrock.py
+++ b/aidial_adapter_bedrock/bedrock.py
@@ -1,4 +1,5 @@
 import json
+import os
 from abc import ABC
 from datetime import datetime
 from functools import cache
@@ -40,6 +41,15 @@ ANTHROPIC_MAX_KEEPALIVE_CONNECTIONS = get_env_int(
 BOTOCORE_CLIENT_MAX_POOL_CONNECTIONS = get_env_int(
     "BOTOCORE_CLIENT_MAX_POOL_CONNECTIONS", 1000
 )
+ANTHROPIC_MAX_RETRY_ATTEMPTS = get_env_int("ANTHROPIC_MAX_RETRY_ATTEMPTS", 0)
+
+
+def _get_botocore_max_retry_attempts():
+    if (value := os.getenv("BOTOCORE_MAX_RETRY_ATTEMPTS")) is not None:
+        return int(value)
+    if (value := os.getenv("AWS_MAX_ATTEMPTS")) is not None:
+        return int(value) - 1
+    return 0
 
 
 @cache
@@ -75,7 +85,7 @@ async def create_anthropic_client(
         anthropic_client = AsyncAnthropic(
             api_key=upstream_config.api_key,
             http_client=http_client,
-            max_retries=0,
+            max_retries=ANTHROPIC_MAX_RETRY_ATTEMPTS,
         )
         return (None, anthropic_client)
     else:
@@ -86,7 +96,7 @@ async def create_anthropic_client(
             aws_secret_key=creds.aws_secret_access_key,
             aws_session_token=creds.aws_session_token,
             http_client=http_client,
-            max_retries=0,
+            max_retries=ANTHROPIC_MAX_RETRY_ATTEMPTS,
         )
         return expiration, anthropic_client
 
@@ -104,7 +114,7 @@ async def create_boto_client(
         max_pool_connections=BOTOCORE_CLIENT_MAX_POOL_CONNECTIONS,
         retries={
             "mode": "standard",
-            "total_max_attempts": get_env_int("AWS_MAX_ATTEMPTS", 1),
+            "total_max_attempts": 1 + _get_botocore_max_retry_attempts(),
         },
     )
 


### PR DESCRIPTION
Resolves #356 

Analogous to https://github.com/epam/ai-dial-adapter-vertexai/pull/344

Retries aren't the responsibility of the adapter. It's the responsibility of:
* DIAL Core, which can call one upstream after another until either an upstream returns a non-retriable status code or all upstreams have been tried at least once. The max number of attempts is controlled by the `maxRetryAttempts` per-deployment parameter.
* DIAL Client, which is using an HTTP client or LLM SDK (such as `openai`) that usually has a default retry logic built into it.

Before:
* Anthropic [max attempts](https://github.com/anthropics/anthropic-sdk-python/blob/2eb941512885bdea844cb46e3f93b60ffa51973b/src/anthropic/_constants.py#L10) = 3
* Botocore [max attempts](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html#legacy-retry-mode) = 5

After:
* Anthropic max attempts = 1 
* Botocore max attempts = 1 _(controlled by `AWS_MAX_ATTEMPTS` env var; default is 1)_

Added env vars controlling retry attempts:

|Variable|Default|Description|
|---|---|---|
|ANTHROPIC_MAX_RETRY_ATTEMPTS|0|How many times to retry Anthropic chat model requests when the provider returns a retriable error|
|BOTOCORE_MAX_RETRY_ATTEMPTS|0|How many times to retry chat model requests made via the Bedrock API or Converse API when the provider returns a retriable error|

To restore the behaviour **before** the fix, configure the env vars in the following way:

```ini
ANTHROPIC_MAX_RETRY_ATTEMPTS=2
BOTOCORE_MAX_RETRY_ATTEMPTS=4
```