### PR TITLE
feat: propagate Retry-After header on Anthropic rate limit errors

### DIFF
--- a/aidial_adapter_bedrock/server/exceptions.py
+++ b/aidial_adapter_bedrock/server/exceptions.py
@@ -74,11 +74,22 @@ def _parse_anthropic_streaming_error(text: str) -> DialException | None:
     return None
 
 
-def _create_error(status_code: int, message: str) -> DialException:
+def _copy_headers(e: APIStatusError, keys: list[str]) -> dict[str, str] | None:
+    copied_headers: dict[str, str] = {}
+    for key in keys:
+        if key in e.response.headers:
+            copied_headers[key] = e.response.headers[key]
+    return copied_headers or None
+
+
+def _create_error(
+    status_code: int, message: str, headers: dict[str, str] | None = None
+) -> DialException:
     return DialException(
         status_code=status_code,
         type=_get_exception_type(status_code),
         message=message,
+        headers=headers,
     )
 
 
@@ -184,7 +195,11 @@ def to_dial_exception(e: Exception) -> DialException:
 
     if isinstance(e, APIStatusError):
         message = _get_anthropic_error_message(e)
-        return _create_error(e.status_code, message)
+        # We want to save Retry-After header if it presents:
+        # https://platform.claude.com/docs/en/api/rate-limits#tier-1
+
+        headers = _copy_headers(e, ["Retry-After"])
+        return _create_error(e.status_code, message, headers)
 
     if isinstance(e, ValidationError):
         return e.to_dial_exception()

--- a/tests/integration_tests/test_anthropic_error.py
+++ b/tests/integration_tests/test_anthropic_error.py
@@ -65,3 +65,51 @@ async def test_anthropic_error_streaming(get_openai_client, streaming: bool):
         "type": "invalid_request_error",
         "message": "messages.1.content.1.text.citations: Extra inputs are not permitted",
     }
+
+
+@respx.mock
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_anthropic_error_rate_limit(
+    get_openai_client,
+    streaming: bool,
+):
+    client: openai.AsyncAzureOpenAI = get_openai_client(
+        _DEPLOYMENT.value, region=_REGION
+    )
+    client.max_retries = 0
+
+    endpoint = "invoke-with-response-stream" if streaming else "invoke"
+
+    respx.post(
+        f"https://bedrock-runtime.{_REGION}.amazonaws.com/model/{_DEPLOYMENT.value}/{endpoint}",
+    ).respond(
+        status_code=429,
+        json={
+            "type": "error",
+            "error": {
+                "type": "rate_limit_error",
+                "message": (
+                    "This request would exceed the rate limit for your organization "
+                    "(test-org-id) of 30,000 input tokens per minute."
+                ),
+            },
+            "request_id": "req_test_123",
+        },
+        headers={
+            "Content-Type": "application/json",
+            "Retry-After": "9",
+        },
+    )
+
+    with pytest.raises(openai.RateLimitError) as exc_info:
+        await chat_completion(
+            client,
+            messages=[user("test")],
+            stream=streaming,
+        )
+
+    exc = exc_info.value
+
+    assert exc.status_code == 429
+    assert exc.response.headers is not None
+    assert exc.response.headers.get("Retry-After") == "9"


### PR DESCRIPTION
Tested that Converse API adapter doesn't cause presence Retry-After in the header as well as Bedrock Anthropic API, while direct communicating with Anthropic actually does.

Fixes https://github.com/epam/ai-dial-adapter-bedrock/issues/365