### PR TITLE
feat: Claude: support different types of plain text documents

### DIFF
--- a/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/adapter.py
@@ -92,7 +92,7 @@ from aidial_adapter_bedrock.llm.model.attachment_processor import (
 from aidial_adapter_bedrock.llm.model.claude.v3.blocks import (
     IMAGE_ATTACHMENT_PROCESSOR,
     PDF_ATTACHMENT_PROCESSOR,
-    TEXT_ATTACHMENT_PROCESSOR,
+    PLAIN_TEXT_ATTACHMENT_PROCESSOR,
     create_text_block,
 )
 from aidial_adapter_bedrock.llm.model.claude.v3.config import (
@@ -205,7 +205,7 @@ class Adapter(ChatCompletionAdapter):
             attachment_processors=(
                 [IMAGE_ATTACHMENT_PROCESSOR]
                 + (
-                    [PDF_ATTACHMENT_PROCESSOR, TEXT_ATTACHMENT_PROCESSOR]
+                    [PDF_ATTACHMENT_PROCESSOR, PLAIN_TEXT_ATTACHMENT_PROCESSOR]
                     if supports_documents
                     else []
                 )

--- a/aidial_adapter_bedrock/llm/model/claude/v3/blocks.py
+++ b/aidial_adapter_bedrock/llm/model/claude/v3/blocks.py
@@ -52,7 +52,7 @@ def create_text_document_block(
     return RequestDocumentBlockParam(
         source=PlainTextSourceParam(
             data=resource.data.decode("utf-8"),
-            media_type=resource.type,  # type: ignore
+            media_type="text/plain",
             type="text",
         ),
         type="document",
@@ -66,7 +66,7 @@ def create_pdf_document_block(
     return RequestDocumentBlockParam(
         source=Base64PDFSourceParam(
             data=resource.data_base64,
-            media_type=resource.type,  # type: ignore
+            media_type="application/pdf",
             type="base64",
         ),
         type="document",
@@ -108,7 +108,23 @@ PDF_ATTACHMENT_PROCESSOR = AttachmentProcessor(
     handler=create_pdf_document_block,
 )
 
-TEXT_ATTACHMENT_PROCESSOR = AttachmentProcessor(
-    supported_types={"text/plain": {"txt"}},
+PLAIN_TEXT_ATTACHMENT_PROCESSOR = AttachmentProcessor(
+    supported_types={
+        "text/plain": {"txt"},
+        "text/html": {"html", "htm"},
+        "text/css": {"css"},
+        "text/javascript": {"js"},
+        "application/x-javascript": {"js"},
+        "text/x-typescript": {"ts"},
+        "application/x-typescript": {"ts"},
+        "text/csv": {"csv"},
+        "text/markdown": {"md"},
+        "text/x-python": {"py"},
+        "application/x-python-code": {"py"},
+        "application/json": {"json"},
+        "text/xml": {"xml"},
+        "application/rtf": {"rtf"},
+        "text/rtf": {"rtf"},
+    },
     handler=create_text_document_block,
 )

--- a/tests/assets/doc.md
+++ b/tests/assets/doc.md
@@ -1,0 +1,1 @@
+Hello world!

--- a/tests/integration_tests/constants.py
+++ b/tests/integration_tests/constants.py
@@ -22,6 +22,10 @@ EXCEL_DOCUMENT_RESOURCE = Resource(
     data=Path("tests/assets/table.xlsx").read_bytes(),
 )
 
+MARKDOWN_DOCUMENT_RESOURCE = Resource(
+    type="text/markdown", data=Path("tests/assets/doc.md").read_bytes()
+)
+
 SAMPLE_DOCUMENT_RESOURCE = Resource.from_base64(
     type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     data_base64="iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAIAAADZSiLoAAAAF0lEQVR4nGNkYPjPwMDAwMDAxAADCBYAG10BBdmz9y8AAAAASUVORK5CYII=",

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -11,6 +11,7 @@ from tests.integration_tests.constants import (
     DOG_PICTURE,
     DOG_PICTURE_CONTENT,
     EXCEL_DOCUMENT_RESOURCE,
+    MARKDOWN_DOCUMENT_RESOURCE,
     PDF_DOCUMENT_RESOURCE,
 )
 from tests.unit_tests.test_configuration import (
@@ -1017,6 +1018,25 @@ async def test_excel_document(optimized_latency: bool, chat: Chat):
             display_message=error_message,
         ):
             await _run()
+
+
+@pytest.mark.parametrize(
+    "deployment",
+    select(pred(supports_document_understanding), deployments),
+    ids=display_deployment,
+)
+@pytest.mark.parametrize("stream", [False], ids=lambda _: "block")
+async def test_markdown_document(chat: Chat):
+    response = await chat(
+        messages=[
+            user_with_attachment_url(
+                "what does the Markdown document say?",
+                MARKDOWN_DOCUMENT_RESOURCE,
+            ),
+        ],
+    )
+
+    assert "hello" in response.content.lower()
 
 
 @pytest.mark.parametrize("deployment", deployments, ids=display_deployment)


### PR DESCRIPTION
The list of supported plain-text document types was borrowed from the [VertexAI adapter](https://github.com/epam/ai-dial-adapter-vertexai/blob/d3318c382517c1b6a4f2016560ea98a7803c3fd1/aidial_adapter_vertexai/chat/gemini/processors.py#L40-L62) to achieve feature parity.

