### PR TITLE
chore: configure pre-push hooks by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_install_hook_types: [pre-push]
+default_stages: [pre-push]
+
 repos:
   - repo: local
     hooks:
@@ -6,11 +9,9 @@ repos:
         pass_filenames: false
         entry: make format
         language: system
-        stages: [pre-push]
 
       - id: make-lint
         name: Make Lint
         pass_filenames: false
         entry: make lint
         language: system
-        stages: [pre-push]


### PR DESCRIPTION
Configure pre-commit so that `pre-commit install` installs pre-push hooks by default.