### PR TITLE
fix: Messages API passthrough: fix mismatching content encodings

### DIFF
--- a/aidial_adapter_bedrock/claude_api.py
+++ b/aidial_adapter_bedrock/claude_api.py
@@ -16,7 +16,6 @@ from aidial_adapter_bedrock.server.exceptions import (
     anthropic_exception_decorator,
 )
 from aidial_adapter_bedrock.upstream_config import parse_upstream_config
-from aidial_adapter_bedrock.utils.log_config import bedrock_logger as log
 
 app = FastAPI()
 
@@ -52,7 +51,6 @@ async def _sse_to_bytes_iterator(
     event: AsyncIterator[ServerSentEvent],
 ) -> AsyncIterator[bytes]:
     async for sse in event:
-        log.debug(f"Yielding SSE: {sse}")
         if sse.id is not None:
             yield f"id: {sse.id}\n".encode()
         if sse.event is not None:
@@ -62,6 +60,16 @@ async def _sse_to_bytes_iterator(
         if sse.retry is not None:
             yield f"retry: {sse.retry}\n".encode()
         yield b"\n"
+
+
+def _strip_content_headers(response_headers: httpx.Headers) -> None:
+    # The adapter decodes the response body before forwarding it, so the
+    # Content-Encoding header no longer applies. Leaving it would cause the
+    # downstream client to attempt a second decompression and fail.
+    response_headers.pop("Content-Encoding", None)
+    # Content-Length reflected the compressed size; after decoding it no longer
+    # matches the body, so drop it and let the framework recompute it.
+    response_headers.pop("Content-Length", None)
 
 
 @anthropic_exception_decorator
@@ -101,8 +109,7 @@ async def _proxy(request: Request, path: str) -> Response:
         stream = _stream()
         if isinstance(client, AsyncAnthropicBedrock):
             response.headers["Content-Type"] = "text/event-stream"
-            response.headers.pop("Content-Encoding", None)
-            response.headers.pop("Content-Length", None)
+            _strip_content_headers(response.headers)
             stream = _sse_to_bytes_iterator(_bedrock_stream_to_sse(stream))
 
         return StreamingResponse(
@@ -112,8 +119,10 @@ async def _proxy(request: Request, path: str) -> Response:
         )
 
     else:
+        content = await response.aread()
+        _strip_content_headers(response.headers)
         return Response(
-            content=await response.aread(),
+            content=content,
             status_code=response.status_code,
             headers=response.headers,
         )

--- a/aidial_adapter_bedrock/claude_api.py
+++ b/aidial_adapter_bedrock/claude_api.py
@@ -69,6 +69,7 @@ def _strip_content_headers(response_headers: httpx.Headers) -> None:
     response_headers.pop("Content-Encoding", None)
     # Content-Length reflected the compressed size; after decoding it no longer
     # matches the body, so drop it and let the framework recompute it.
+    # And even when the content was uncompressed to begin with (which is the case for streaming), the content length can change do to the SSE reformatting.
     response_headers.pop("Content-Length", None)
 
 

--- a/tests/unit_tests/test_claude_api.py
+++ b/tests/unit_tests/test_claude_api.py
@@ -1,3 +1,4 @@
+import gzip
 from collections.abc import Iterable
 from pathlib import Path
 from typing import TypedDict
@@ -94,6 +95,28 @@ class TestMessagesNonStreaming:
         text_block = response.content[0]
         assert isinstance(text_block, anthropic.types.TextBlock)
         assert text_block.text == "Hello! How can I assist you today?"
+
+    @respx.mock
+    async def test_http_gzip_encoding_stripped(
+        self, mock: respx.MockRouter, http_client: httpx.AsyncClient
+    ):
+        content = _read_fixture("messages_non_streaming_response.json")
+        mock.post(url="/v1/messages").respond(
+            content=gzip.compress(content),
+            content_type="application/json",
+            headers={"Content-Encoding": "gzip"},
+        )
+
+        response = await http_client.post(
+            "/v1/messages",
+            json=_MESSAGES_REQUEST,
+            headers={"Accept-Encoding": "gzip"},
+        )
+
+        assert response.status_code == 200
+        assert "content-encoding" not in response.headers
+        body = response.json()
+        assert body["type"] == "message"
 
 
 class TestMessagesStreaming:


### PR DESCRIPTION
Fixes #449

- After `aread()` decodes the response body, the upstream `Content-Encoding: gzip` header was still forwarded verbatim, causing DIAL Core to attempt a second decompression and fail
- Strip `Content-Encoding` and `Content-Length` in the non-streaming path (the Bedrock streaming path already did this)
- Extract the two pops into `_strip_content_headers()` and reuse it in both paths
- Add `test_http_gzip_encoding_stripped` to cover the bug scenario directly

This highlights the current limitation of Messages API passthrough - all non-streaming responses are **uncompressed**.