### PR TITLE
feat: log Messages API passthrough request and response

### DIFF
--- a/aidial_adapter_bedrock/claude_api.py
+++ b/aidial_adapter_bedrock/claude_api.py
@@ -1,6 +1,13 @@
 import contextlib
 import json
-from collections.abc import AsyncIterator
+import logging
+from collections.abc import (
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+)
+from functools import wraps
 
 import httpx
 from anthropic import AsyncAnthropicBedrock
@@ -19,6 +26,9 @@ from aidial_adapter_bedrock.upstream_config import parse_upstream_config
 from aidial_adapter_bedrock.utils.log_config import bedrock_logger as log
 
 app = FastAPI()
+
+_Content = str | bytes | memoryview
+_Handler = Callable[[Request, str], Awaitable[Response]]
 
 
 def _is_streaming_request(body: dict | None, path: str) -> bool:
@@ -52,7 +62,6 @@ async def _sse_to_bytes_iterator(
     event: AsyncIterator[ServerSentEvent],
 ) -> AsyncIterator[bytes]:
     async for sse in event:
-        log.debug(f"Yielding SSE: {sse}")
         if sse.id is not None:
             yield f"id: {sse.id}\n".encode()
         if sse.event is not None:
@@ -64,7 +73,52 @@ async def _sse_to_bytes_iterator(
         yield b"\n"
 
 
+def _as_text(data: _Content) -> str:
+    if isinstance(data, str):
+        return data
+    return bytes(data).decode("utf-8", errors="replace")
+
+
+async def _log_stream_chunks(
+    iterator: AsyncIterable[_Content],
+) -> AsyncIterator[_Content]:
+    async for chunk in iterator:
+        with contextlib.suppress(Exception):
+            log.debug(f"response chunk: {_as_text(chunk)}")
+        yield chunk
+
+
+def _logging_decorator(func: _Handler) -> _Handler:
+    """Reports the request and the response of the passthrough endpoint as
+    debug logs.
+
+    The logging is fully gated behind the DEBUG log level, so it has no effect
+    (no response wrapping) unless DEBUG logging is enabled.
+    """
+
+    @wraps(func)
+    async def wrapper(request: Request, path: str) -> Response:
+        if not log.isEnabledFor(logging.DEBUG):
+            return await func(request, path)
+
+        with contextlib.suppress(Exception):
+            log.debug(f"request: {_as_text(await request.body())}")
+
+        response = await func(request, path)
+
+        if isinstance(response, StreamingResponse):
+            response.body_iterator = _log_stream_chunks(response.body_iterator)
+        else:
+            with contextlib.suppress(Exception):
+                log.debug(f"response: {_as_text(response.body)}")
+
+        return response
+
+    return wrapper
+
+
 @anthropic_exception_decorator
+@_logging_decorator
 async def _proxy(request: Request, path: str) -> Response:
     json_body = None
     if content := await request.body():

--- a/aidial_adapter_bedrock/claude_api.py
+++ b/aidial_adapter_bedrock/claude_api.py
@@ -89,13 +89,6 @@ async def _log_stream_chunks(
 
 
 def _logging_decorator(func: _Handler) -> _Handler:
-    """Reports the request and the response of the passthrough endpoint as
-    debug logs.
-
-    The logging is fully gated behind the DEBUG log level, so it has no effect
-    (no response wrapping) unless DEBUG logging is enabled.
-    """
-
     @wraps(func)
     async def wrapper(request: Request, path: str) -> Response:
         if not log.isEnabledFor(logging.DEBUG):

--- a/tests/unit_tests/test_claude_api.py
+++ b/tests/unit_tests/test_claude_api.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterable
 from pathlib import Path
 from typing import TypedDict
@@ -190,6 +191,76 @@ class TestCountTokens:
         )
 
         assert response.input_tokens == 14
+
+
+class TestDebugLogging:
+    # The logs must have no effect unless the log level is DEBUG.
+    @pytest.mark.parametrize(
+        "level, expected", [(logging.DEBUG, True), (logging.INFO, False)]
+    )
+    @respx.mock
+    async def test_request_and_response_logging(
+        self,
+        mock: respx.MockRouter,
+        http_client: httpx.AsyncClient,
+        caplog: pytest.LogCaptureFixture,
+        level: int,
+        expected: bool,
+    ):
+        content = _read_fixture("messages_non_streaming_response.json")
+        mock.post(url="/v1/messages").respond(
+            content=content, content_type="application/json"
+        )
+
+        with caplog.at_level(level, logger="bedrock"):
+            response = await http_client.post(
+                "/v1/messages", json=_MESSAGES_REQUEST
+            )
+
+        assert response.status_code == 200
+
+        messages = [record.getMessage() for record in caplog.records]
+        request_logs = [m for m in messages if m.startswith("request: ")]
+        response_logs = [m for m in messages if m.startswith("response: ")]
+
+        if expected:
+            assert len(request_logs) == 1
+            assert "Say hello." in request_logs[0]
+
+            assert len(response_logs) == 1
+            assert "Hello! How can I assist you today?" in response_logs[0]
+        else:
+            assert not request_logs
+            assert not response_logs
+
+    @respx.mock
+    async def test_streaming_response_chunk_logging(
+        self,
+        mock: respx.MockRouter,
+        http_client: httpx.AsyncClient,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        content = _read_fixture("messages_streaming_response.txt")
+        mock.post("/v1/messages").respond(
+            content=content, content_type="text/event-stream"
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="bedrock"):
+            payload = {**_MESSAGES_REQUEST, "stream": True}
+            response = await http_client.post("/v1/messages", json=payload)
+
+        assert response.status_code == 200
+
+        messages = [record.getMessage() for record in caplog.records]
+        chunk_logs = [m for m in messages if m.startswith("response chunk: ")]
+
+        # The streamed chunks are logged as-is; the number of chunks isn't
+        # deterministic, so we only assert the streamed content is logged.
+        assert chunk_logs
+        streamed = "\n".join(chunk_logs)
+        assert "message_start" in streamed
+        assert "Hello!" in streamed
+        assert "message_stop" in streamed
 
 
 class TestModels:


### PR DESCRIPTION
Fixes #451

### Description of changes
- Add a `_logging_decorator` applied to the passthrough proxy handler that emits debug logs for the request body, the non-streaming response body, and each streamed response chunk.
- Logs are printed as-is (raw content, no JSON parsing) since the payloads may not be JSON.
- Logging is fully gated behind the `DEBUG` log level — it short-circuits and wraps the proxy with zero effect otherwise, so it never interferes with the request or the stream.
- The `_proxy` function itself is unchanged; all logging lives in the decorator.
- Add unit tests covering request/response logging (parametrized over DEBUG/INFO to verify non-invasiveness) and streamed-chunk logging.