### PR TITLE
feat: Messages API passthrough: forward anthropic and encoding headers

### DIFF
--- a/aidial_adapter_bedrock/claude_api.py
+++ b/aidial_adapter_bedrock/claude_api.py
@@ -124,19 +124,11 @@ def _logging_decorator(func: _Handler) -> _Handler:
 
 
 def _build_request_headers(headers: StarletteHeaders) -> dict[str, str]:
-    def _is_anthropic_header(header: str) -> bool:
+    def _keep_header(header: str) -> bool:
         header = header.lower()
-        return header.startswith("anthropic-")
+        return header.startswith("anthropic-") or header == "accept-encoding"
 
-    def _is_content_header(header: str) -> bool:
-        header = header.lower()
-        return header == "accept-encoding"
-
-    return {
-        k: v
-        for (k, v) in headers.items()
-        if _is_anthropic_header(k) or _is_content_header(k)
-    }
+    return {k: v for (k, v) in headers.items() if _keep_header(k)}
 
 
 @anthropic_exception_decorator

--- a/aidial_adapter_bedrock/claude_api.py
+++ b/aidial_adapter_bedrock/claude_api.py
@@ -17,6 +17,7 @@ from anthropic.lib.bedrock._stream_decoder import AWSEventStreamDecoder
 from botocore.eventstream import EventStreamBuffer
 from fastapi import FastAPI, Request
 from fastapi.responses import Response, StreamingResponse
+from starlette.datastructures import Headers as StarletteHeaders
 
 from aidial_adapter_bedrock.bedrock import create_anthropic_client
 from aidial_adapter_bedrock.server.exceptions import (
@@ -80,7 +81,8 @@ def _strip_content_headers(response_headers: httpx.Headers) -> None:
     response_headers.pop("Content-Encoding", None)
     # Content-Length reflected the compressed size; after decoding it no longer
     # matches the body, so drop it and let the framework recompute it.
-    # And even when the content was uncompressed to begin with (which is the case for streaming), the content length can change do to the SSE reformatting.
+    # And even when the content was uncompressed to begin with,
+    # the content length can change do to the SSE reformatting.
     response_headers.pop("Content-Length", None)
 
 
@@ -121,6 +123,22 @@ def _logging_decorator(func: _Handler) -> _Handler:
     return wrapper
 
 
+def _build_request_headers(headers: StarletteHeaders) -> dict[str, str]:
+    def _is_anthropic_header(header: str) -> bool:
+        header = header.lower()
+        return header.startswith("anthropic-")
+
+    def _is_content_header(header: str) -> bool:
+        header = header.lower()
+        return header == "accept-encoding"
+
+    return {
+        k: v
+        for (k, v) in headers.items()
+        if _is_anthropic_header(k) or _is_content_header(k)
+    }
+
+
 @anthropic_exception_decorator
 @_logging_decorator
 async def _proxy(request: Request, path: str) -> Response:
@@ -138,6 +156,7 @@ async def _proxy(request: Request, path: str) -> Response:
         method=request.method.lower(),
         url=path,
         json_data=json_body,
+        headers=_build_request_headers(request.headers),
     )
 
     response = await client.request(

--- a/tests/unit_tests/test_claude_api.py
+++ b/tests/unit_tests/test_claude_api.py
@@ -286,6 +286,42 @@ class TestDebugLogging:
         assert "message_stop" in streamed
 
 
+class TestRequestHeaderPassthrough:
+    @pytest.fixture(autouse=True)
+    def _setup(self, mock: respx.MockRouter):
+        content = _read_fixture("messages_non_streaming_response.json")
+        mock.post(url="/v1/messages").respond(
+            content=content, content_type="application/json"
+        )
+
+    @respx.mock
+    async def test_anthropic_and_encoding_headers_forwarded(
+        self, mock: respx.MockRouter, http_client: httpx.AsyncClient
+    ):
+        response = await http_client.post(
+            "/v1/messages",
+            json=_MESSAGES_REQUEST,
+            headers={
+                "anthropic-beta": "token-efficient-tools-2025-02-19",
+                "Accept-Encoding": "identity",
+                "x-not-forwarded": "should-be-dropped",
+            },
+        )
+
+        assert response.status_code == 200
+
+        upstream_headers = mock.calls.last.request.headers
+        # Anthropic-specific headers must reach the upstream.
+        assert (
+            upstream_headers["anthropic-beta"]
+            == "token-efficient-tools-2025-02-19"
+        )
+        # The encoding-control header must reach the upstream too.
+        assert upstream_headers["accept-encoding"] == "identity"
+        # Unrelated headers must not be forwarded.
+        assert "x-not-forwarded" not in upstream_headers
+
+
 class TestModels:
     @pytest.fixture(autouse=True)
     def _setup(self, mock: respx.MockRouter):


### PR DESCRIPTION
Fixes #454

### Description of changes
- Forward Anthropic-specific request headers (e.g. `anthropic-beta`) to the upstream in the Messages API passthrough, so clients can opt into beta features.
- Forward the encoding-control header (`accept-encoding`) to the upstream so clients can control response encoding.
- Add a unit test asserting that anthropic and encoding headers reach the upstream while unrelated headers are dropped.