### PR TITLE
fix: Messages API passthrough: support logging of encoded responses

### DIFF
--- a/aidial_adapter_bedrock/claude_api.py
+++ b/aidial_adapter_bedrock/claude_api.py
@@ -1,12 +1,7 @@
 import contextlib
 import json
 import logging
-from collections.abc import (
-    AsyncIterable,
-    AsyncIterator,
-    Awaitable,
-    Callable,
-)
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
 from functools import wraps
 
 import httpx
@@ -138,6 +133,15 @@ async def _proxy(request: Request, path: str) -> Response:
         method=request.method.lower(),
         url=path,
         json_data=json_body,
+        # When debug logging is on, ask the upstream not to compress the
+        # response so its body (and streamed chunks) can be logged as-is.
+        # Forgoing compression on the upstream hop is a fair price for
+        # painless logging.
+        headers=(
+            {"Accept-Encoding": "identity"}
+            if log.isEnabledFor(logging.DEBUG)
+            else {}
+        ),
     )
 
     response = await client.request(

--- a/tests/unit_tests/test_claude_api.py
+++ b/tests/unit_tests/test_claude_api.py
@@ -285,6 +285,46 @@ class TestDebugLogging:
         assert "Hello!" in streamed
         assert "message_stop" in streamed
 
+    @pytest.mark.parametrize(
+        "level, expected_encoding",
+        [(logging.DEBUG, "identity"), (logging.INFO, None)],
+    )
+    @respx.mock
+    async def test_debug_disables_upstream_compression(
+        self,
+        mock: respx.MockRouter,
+        http_client: httpx.AsyncClient,
+        caplog: pytest.LogCaptureFixture,
+        level: int,
+        expected_encoding: str | None,
+    ):
+        # With debug logging on, the upstream is asked not to compress the
+        # response (Accept-Encoding: identity) so it can be logged as-is.
+        # Otherwise the client's default (compressed) negotiation is left alone.
+        captured: dict[str, str | None] = {}
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            captured["accept-encoding"] = request.headers.get("accept-encoding")
+            content = _read_fixture("messages_non_streaming_response.json")
+            return httpx.Response(
+                200,
+                content=content,
+                headers={"content-type": "application/json"},
+            )
+
+        mock.post(url="/v1/messages").mock(side_effect=_handler)
+
+        with caplog.at_level(level, logger="bedrock"):
+            response = await http_client.post(
+                "/v1/messages", json=_MESSAGES_REQUEST
+            )
+
+        assert response.status_code == 200
+        if expected_encoding is None:
+            assert captured["accept-encoding"] != "identity"
+        else:
+            assert captured["accept-encoding"] == expected_encoding
+
 
 class TestModels:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Fixes #456

### Description of changes
- Gzip-encoded streamed (and non-streaming) responses forwarded through the Messages API passthrough were logged as unreadable binary at DEBUG level.
- When DEBUG logging is enabled, the adapter now sends `Accept-Encoding: identity` on the upstream request so the response arrives uncompressed and can be logged as-is.
- When DEBUG logging is off, the client's normal compressed content negotiation (`gzip, deflate, zstd`) is left untouched, so production passthrough is unchanged.
- Added a parametrized test verifying the upstream `Accept-Encoding` is `identity` under DEBUG and the default otherwise.