### PR TITLE
fix: Anthropic API passthrough: filter Anthropic beta flags unsupported by Bedrock

### DIFF
--- a/aidial_adapter_bedrock/claude_api.py
+++ b/aidial_adapter_bedrock/claude_api.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
 from functools import wraps
 
 import httpx
-from anthropic import AsyncAnthropicBedrock
+from anthropic import AsyncAnthropicBedrock, AsyncAnthropicBedrockMantle
 from anthropic._models import FinalRequestOptions
 from anthropic._streaming import ServerSentEvent
 from anthropic.lib.bedrock._stream_decoder import AWSEventStreamDecoder
@@ -182,9 +182,10 @@ async def _proxy(request: Request, path: str) -> Response:
     upstream_config = await parse_upstream_config(request)
     client = await create_anthropic_client(upstream_config)
 
-    headers = _build_request_headers(
-        request.headers, is_bedrock=isinstance(client, AsyncAnthropicBedrock)
+    is_bedrock = isinstance(
+        client, (AsyncAnthropicBedrock | AsyncAnthropicBedrockMantle)
     )
+    headers = _build_request_headers(request.headers, is_bedrock=is_bedrock)
     if log.isEnabledFor(logging.DEBUG):
         # Ask the upstream not to compress the response so its body (and
         # streamed chunks) can be logged as-is. Forgoing compression on the

--- a/aidial_adapter_bedrock/claude_api.py
+++ b/aidial_adapter_bedrock/claude_api.py
@@ -5,7 +5,6 @@ from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
 from functools import wraps
 
 import httpx
-from aidial_sdk.exceptions import HTTPException as DialException
 from anthropic import AsyncAnthropicBedrock
 from anthropic._models import FinalRequestOptions
 from anthropic._streaming import ServerSentEvent
@@ -27,11 +26,6 @@ app = FastAPI()
 
 _Content = str | bytes | memoryview
 _Handler = Callable[[Request, str], Awaitable[Response]]
-
-
-@app.exception_handler(DialException)
-async def _dial_exception_handler(_request: Request, e: DialException):
-    return e.to_fastapi_response()
 
 
 def _is_streaming_request(body: dict | None, path: str) -> bool:
@@ -125,64 +119,51 @@ def _logging_decorator(func: _Handler) -> _Handler:
     return wrapper
 
 
-# Header that carries the platform api-key. Its presence routes the request to
-# the Anthropic API; its absence means the request targets a Bedrock model.
-# Mirrors ``ApiKeyUpstreamConfig._UPSTREAM_API_KEY_HEADER_NAME``.
-_UPSTREAM_API_KEY_HEADER_NAME = "x-upstream-key"
-_ANTHROPIC_BETA_HEADER_NAME = "anthropic-beta"
-
-# Beta feature flags accepted by the Anthropic API but not by Bedrock. For a
-# Bedrock request each listed flag is dropped (mapped to ``None``) or rewritten
-# to its Bedrock equivalent (mapped to a string); flags absent from the map are
-# forwarded unchanged.
-_ANTHROPIC_BETA_BEDROCK_MAP: dict[str, str | None] = {
-    "oauth-2025-04-20": None,
-    "redact-thinking-2026-02-12": None,
-    "thinking-token-count-2026-05-13": None,
-    "prompt-caching-scope-2026-01-05": None,
-    "claude-code-20250219": None,
-    "advisor-tool-2026-03-01": None,
+_UNSUPPORTED_BEDROCK_ANTHROPIC_BETA_FLAGS = {
+    "oauth-2025-04-20",
+    "redact-thinking-2026-02-12",
+    "thinking-token-count-2026-05-13",
+    "prompt-caching-scope-2026-01-05",
+    "claude-code-20250219",
+    "advisor-tool-2026-03-01",
 }
 
 
-def _adapt_anthropic_beta_for_bedrock(header_value: str) -> str | None:
-    """Rewrite the comma-separated ``anthropic-beta`` header for Bedrock.
-
-    Flags Bedrock doesn't accept are dropped or rewritten per
-    ``_ANTHROPIC_BETA_BEDROCK_MAP``; unknown flags pass through. Returns the
-    new header value, or ``None`` when no flags remain.
-    """
-    betas: list[str] = []
-    for beta in header_value.split(","):
-        beta = beta.strip()
-        if not beta:
-            continue
-        if beta in _ANTHROPIC_BETA_BEDROCK_MAP:
-            replacement = _ANTHROPIC_BETA_BEDROCK_MAP[beta]
-            if replacement is None:
-                continue
-            beta = replacement
-        betas.append(beta)
-    return ",".join(betas) or None
+def _adapt_anthropic_beta_for_bedrock(value: str | None) -> str | None:
+    if value is None:
+        return None
+    features = [
+        feature
+        for feature in value.split(",")
+        if feature not in _UNSUPPORTED_BEDROCK_ANTHROPIC_BETA_FLAGS
+    ]
+    return ",".join(features) or None
 
 
-def _build_request_headers(headers: StarletteHeaders) -> dict[str, str]:
+def _on_dict_value(
+    dct: dict[str, str], kye: str, func: Callable[[str | None], str | None]
+) -> dict[str, str]:
+    value = func(dct.get(kye))
+    if value is None:
+        dct.pop(kye, None)
+    else:
+        dct[kye] = value
+    return dct
+
+
+def _build_request_headers(
+    headers: StarletteHeaders, *, is_bedrock: bool
+) -> dict[str, str]:
     def _keep_header(header: str) -> bool:
         header = header.lower()
         return header.startswith("anthropic-") or header == "accept-encoding"
 
-    result = {k: v for (k, v) in headers.items() if _keep_header(k)}
+    result = {k.lower(): v for (k, v) in headers.items() if _keep_header(k)}
 
-    # A Bedrock request (no platform api-key) supports a different set of
-    # beta flags than the Anthropic API, so adapt the header accordingly.
-    is_bedrock = _UPSTREAM_API_KEY_HEADER_NAME not in headers
-    beta = result.get(_ANTHROPIC_BETA_HEADER_NAME)
-    if is_bedrock and beta is not None:
-        adapted = _adapt_anthropic_beta_for_bedrock(beta)
-        if adapted is None:
-            del result[_ANTHROPIC_BETA_HEADER_NAME]
-        else:
-            result[_ANTHROPIC_BETA_HEADER_NAME] = adapted
+    if is_bedrock:
+        result = _on_dict_value(
+            result, "anthropic-beta", _adapt_anthropic_beta_for_bedrock
+        )
 
     return result
 
@@ -201,7 +182,9 @@ async def _proxy(request: Request, path: str) -> Response:
     upstream_config = await parse_upstream_config(request)
     client = await create_anthropic_client(upstream_config)
 
-    headers = _build_request_headers(request.headers)
+    headers = _build_request_headers(
+        request.headers, is_bedrock=isinstance(client, AsyncAnthropicBedrock)
+    )
     if log.isEnabledFor(logging.DEBUG):
         # Ask the upstream not to compress the response so its body (and
         # streamed chunks) can be logged as-is. Forgoing compression on the

--- a/aidial_adapter_bedrock/claude_api.py
+++ b/aidial_adapter_bedrock/claude_api.py
@@ -125,12 +125,66 @@ def _logging_decorator(func: _Handler) -> _Handler:
     return wrapper
 
 
+# Header that carries the platform api-key. Its presence routes the request to
+# the Anthropic API; its absence means the request targets a Bedrock model.
+# Mirrors ``ApiKeyUpstreamConfig._UPSTREAM_API_KEY_HEADER_NAME``.
+_UPSTREAM_API_KEY_HEADER_NAME = "x-upstream-key"
+_ANTHROPIC_BETA_HEADER_NAME = "anthropic-beta"
+
+# Beta feature flags accepted by the Anthropic API but not by Bedrock. For a
+# Bedrock request each listed flag is dropped (mapped to ``None``) or rewritten
+# to its Bedrock equivalent (mapped to a string); flags absent from the map are
+# forwarded unchanged.
+_ANTHROPIC_BETA_BEDROCK_MAP: dict[str, str | None] = {
+    "oauth-2025-04-20": None,
+    "redact-thinking-2026-02-12": None,
+    "thinking-token-count-2026-05-13": None,
+    "prompt-caching-scope-2026-01-05": None,
+    "claude-code-20250219": None,
+    "advisor-tool-2026-03-01": None,
+}
+
+
+def _adapt_anthropic_beta_for_bedrock(header_value: str) -> str | None:
+    """Rewrite the comma-separated ``anthropic-beta`` header for Bedrock.
+
+    Flags Bedrock doesn't accept are dropped or rewritten per
+    ``_ANTHROPIC_BETA_BEDROCK_MAP``; unknown flags pass through. Returns the
+    new header value, or ``None`` when no flags remain.
+    """
+    betas: list[str] = []
+    for beta in header_value.split(","):
+        beta = beta.strip()
+        if not beta:
+            continue
+        if beta in _ANTHROPIC_BETA_BEDROCK_MAP:
+            replacement = _ANTHROPIC_BETA_BEDROCK_MAP[beta]
+            if replacement is None:
+                continue
+            beta = replacement
+        betas.append(beta)
+    return ",".join(betas) or None
+
+
 def _build_request_headers(headers: StarletteHeaders) -> dict[str, str]:
     def _keep_header(header: str) -> bool:
         header = header.lower()
         return header.startswith("anthropic-") or header == "accept-encoding"
 
-    return {k: v for (k, v) in headers.items() if _keep_header(k)}
+    result = {k: v for (k, v) in headers.items() if _keep_header(k)}
+
+    # A Bedrock request (no platform api-key) supports a different set of
+    # beta flags than the Anthropic API, so adapt the header accordingly.
+    is_bedrock = _UPSTREAM_API_KEY_HEADER_NAME not in headers
+    beta = result.get(_ANTHROPIC_BETA_HEADER_NAME)
+    if is_bedrock and beta is not None:
+        adapted = _adapt_anthropic_beta_for_bedrock(beta)
+        if adapted is None:
+            del result[_ANTHROPIC_BETA_HEADER_NAME]
+        else:
+            result[_ANTHROPIC_BETA_HEADER_NAME] = adapted
+
+    return result
 
 
 @dial_exception_decorator

--- a/tests/unit_tests/test_claude_api.py
+++ b/tests/unit_tests/test_claude_api.py
@@ -14,7 +14,6 @@ from anthropic.types import MessageParam
 from httpx import ASGITransport
 from starlette.datastructures import Headers as StarletteHeaders
 
-import aidial_adapter_bedrock.claude_api as claude_api
 from aidial_adapter_bedrock.claude_api import _build_request_headers, app
 
 
@@ -367,58 +366,34 @@ class TestRequestHeaderPassthrough:
 
 
 class TestBuildRequestHeaders:
-    # Bedrock is selected by the absence of the ``x-upstream-key`` header.
     _BETA = "anthropic-beta"
+
+    def _build(self, headers: StarletteHeaders) -> dict[str, str]:
+        return _build_request_headers(headers, is_bedrock=True)
 
     def test_bedrock_drops_unsupported_beta_flags(self):
         headers = StarletteHeaders(
             headers={
-                self._BETA: (
-                    "oauth-2025-04-20,token-efficient-tools-2025-02-19"
-                )
+                self._BETA: "oauth-2025-04-20,token-efficient-tools-2025-02-19"
             }
         )
-        result = _build_request_headers(headers)
+        result = self._build(headers)
         assert result[self._BETA] == "token-efficient-tools-2025-02-19"
 
     def test_bedrock_removes_header_when_all_flags_unsupported(self):
         headers = StarletteHeaders(
             headers={
-                self._BETA: (
-                    "oauth-2025-04-20, thinking-token-count-2026-05-13"
-                )
+                self._BETA: "oauth-2025-04-20,thinking-token-count-2026-05-13"
             }
         )
-        result = _build_request_headers(headers)
+        result = self._build(headers)
         assert self._BETA not in result
-
-    def test_bedrock_replaces_mapped_beta_flag(self, monkeypatch):
-        monkeypatch.setitem(
-            claude_api._ANTHROPIC_BETA_BEDROCK_MAP,
-            "renamed-source-2025-01-01",
-            "renamed-target-2025-01-01",
-        )
-        headers = StarletteHeaders(
-            headers={self._BETA: "renamed-source-2025-01-01,keep-me"}
-        )
-        result = _build_request_headers(headers)
-        assert result[self._BETA] == "renamed-target-2025-01-01,keep-me"
 
     def test_bedrock_without_beta_header_is_unchanged(self):
         headers = StarletteHeaders(headers={"accept-encoding": "gzip"})
-        result = _build_request_headers(headers)
+        result = self._build(headers)
         assert self._BETA not in result
         assert result["accept-encoding"] == "gzip"
-
-    def test_api_key_request_keeps_beta_flags_untouched(self):
-        # With ``x-upstream-key`` present the request targets the Anthropic
-        # API, whose beta flags are forwarded verbatim.
-        value = "oauth-2025-04-20, thinking-token-count-2026-05-13"
-        headers = StarletteHeaders(
-            headers={"x-upstream-key": "sk-test", self._BETA: value}
-        )
-        result = _build_request_headers(headers)
-        assert result[self._BETA] == value
 
 
 class TestBedrockAnthropicBetaAdaptation:

--- a/tests/unit_tests/test_claude_api.py
+++ b/tests/unit_tests/test_claude_api.py
@@ -12,8 +12,10 @@ import respx
 from anthropic._streaming import ServerSentEvent
 from anthropic.types import MessageParam
 from httpx import ASGITransport
+from starlette.datastructures import Headers as StarletteHeaders
 
-from aidial_adapter_bedrock.claude_api import app
+import aidial_adapter_bedrock.claude_api as claude_api
+from aidial_adapter_bedrock.claude_api import _build_request_headers, app
 
 
 def _read_fixture(name: str) -> bytes:
@@ -362,6 +364,107 @@ class TestRequestHeaderPassthrough:
         assert upstream_headers["accept-encoding"] == "identity"
         # Unrelated headers must not be forwarded.
         assert "x-not-forwarded" not in upstream_headers
+
+
+class TestBuildRequestHeaders:
+    # Bedrock is selected by the absence of the ``x-upstream-key`` header.
+    _BETA = "anthropic-beta"
+
+    def test_bedrock_drops_unsupported_beta_flags(self):
+        headers = StarletteHeaders(
+            headers={
+                self._BETA: (
+                    "oauth-2025-04-20,token-efficient-tools-2025-02-19"
+                )
+            }
+        )
+        result = _build_request_headers(headers)
+        assert result[self._BETA] == "token-efficient-tools-2025-02-19"
+
+    def test_bedrock_removes_header_when_all_flags_unsupported(self):
+        headers = StarletteHeaders(
+            headers={
+                self._BETA: (
+                    "oauth-2025-04-20, thinking-token-count-2026-05-13"
+                )
+            }
+        )
+        result = _build_request_headers(headers)
+        assert self._BETA not in result
+
+    def test_bedrock_replaces_mapped_beta_flag(self, monkeypatch):
+        monkeypatch.setitem(
+            claude_api._ANTHROPIC_BETA_BEDROCK_MAP,
+            "renamed-source-2025-01-01",
+            "renamed-target-2025-01-01",
+        )
+        headers = StarletteHeaders(
+            headers={self._BETA: "renamed-source-2025-01-01,keep-me"}
+        )
+        result = _build_request_headers(headers)
+        assert result[self._BETA] == "renamed-target-2025-01-01,keep-me"
+
+    def test_bedrock_without_beta_header_is_unchanged(self):
+        headers = StarletteHeaders(headers={"accept-encoding": "gzip"})
+        result = _build_request_headers(headers)
+        assert self._BETA not in result
+        assert result["accept-encoding"] == "gzip"
+
+    def test_api_key_request_keeps_beta_flags_untouched(self):
+        # With ``x-upstream-key`` present the request targets the Anthropic
+        # API, whose beta flags are forwarded verbatim.
+        value = "oauth-2025-04-20, thinking-token-count-2026-05-13"
+        headers = StarletteHeaders(
+            headers={"x-upstream-key": "sk-test", self._BETA: value}
+        )
+        result = _build_request_headers(headers)
+        assert result[self._BETA] == value
+
+
+class TestBedrockAnthropicBetaAdaptation:
+    async def test_bedrock_request_adapts_beta_header(self, monkeypatch):
+        captured: dict[str, dict[str, str]] = {}
+
+        class _CapturingClient:
+            async def request(self, *, options, **_kwargs):
+                captured["headers"] = options.headers
+                content = _read_fixture("messages_non_streaming_response.json")
+                return _FakeStreamingResponse(
+                    chunks=[content],
+                    headers={"Content-Type": "application/json"},
+                )
+
+        async def _create_client(_upstream):
+            return _CapturingClient()
+
+        monkeypatch.setattr(
+            "aidial_adapter_bedrock.claude_api.create_anthropic_client",
+            _create_client,
+        )
+
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app),  # type: ignore
+            base_url="http://test-app.com",
+            headers={"x-upstream-extra-data": json.dumps({})},
+        ) as client:
+            response = await client.post(
+                "/v1/messages",
+                json=_MESSAGES_REQUEST,
+                headers={
+                    "anthropic-beta": (
+                        "oauth-2025-04-20,"
+                        "token-efficient-tools-2025-02-19,"
+                        "thinking-token-count-2026-05-13"
+                    )
+                },
+            )
+
+        assert response.status_code == 200
+        # Bedrock-unsupported flags are stripped; the unknown flag survives.
+        assert (
+            captured["headers"]["anthropic-beta"]
+            == "token-efficient-tools-2025-02-19"
+        )
 
 
 class TestModels:

--- a/tests/unit_tests/test_claude_api.py
+++ b/tests/unit_tests/test_claude_api.py
@@ -94,10 +94,24 @@ async def http_client_bedrock_mantle():
         transport=ASGITransport(app),  # type: ignore
         base_url="http://test-app.com",
         headers={
-            "x-upstream-extra-data": json.dumps({"claude_client": "mantle"})
+            "x-upstream-extra-data": json.dumps(
+                {
+                    "claude_client": "mantle",
+                    "aws_access_key_id": "test-access-key",
+                    "aws_secret_access_key": "test-secret-key",
+                }
+            )
         },
     ) as client:
         yield client
+
+
+@pytest.fixture
+def mock_bedrock_mantle():
+    with respx.mock(
+        base_url="https://bedrock-mantle.test-region.api.aws/anthropic"
+    ) as mock:
+        yield mock
 
 
 @pytest.fixture
@@ -463,17 +477,28 @@ class TestBedrockAnthropicBetaAdaptation:
         mock_bedrock: respx.MockRouter,
         http_client_bedrock_legacy: httpx.AsyncClient,
     ):
-        # Uses a real AsyncAnthropicBedrock client (rather than patching
-        # create_anthropic_client with a stand-in) so that the adapter's
-        # `isinstance(client, AsyncAnthropicBedrock)` check actually holds
-        # and the beta-header filtering logic is exercised.
-        content = _read_fixture("messages_non_streaming_response.json")
-
         route = mock_bedrock.post(path__regex=r"^/model/.*/invoke$").respond(
-            content=content, content_type="application/json"
+            content=_read_fixture("messages_non_streaming_response.json"),
+            content_type="application/json",
         )
+        await self._call_and_check_headers(http_client_bedrock_legacy, route)
 
-        response = await http_client_bedrock_legacy.post(
+    @respx.mock
+    async def test_bedrock_mantle_request_adapts_beta_header(
+        self,
+        mock_bedrock_mantle: respx.MockRouter,
+        http_client_bedrock_mantle: httpx.AsyncClient,
+    ):
+        route = mock_bedrock_mantle.post(path="/v1/messages").respond(
+            content=_read_fixture("messages_non_streaming_response.json"),
+            content_type="application/json",
+        )
+        await self._call_and_check_headers(http_client_bedrock_mantle, route)
+
+    async def _call_and_check_headers(
+        self, client: httpx.AsyncClient, route: respx.Route
+    ):
+        response = await client.post(
             "/v1/messages",
             json=_MESSAGES_REQUEST,
             headers={

--- a/tests/unit_tests/test_claude_api.py
+++ b/tests/unit_tests/test_claude_api.py
@@ -49,20 +49,54 @@ def mock():
 
 
 @pytest.fixture
-async def http_client():
+async def http_client_platform():
     async with httpx.AsyncClient(
         transport=ASGITransport(app),  # type: ignore
         base_url="http://test-app.com",
-        headers={"x-upstream-key": "test-claude-api-key"},
+        headers={
+            "x-upstream-key": "test-claude-api-key",
+            "aws_access_key_id": "test-access-key",
+            "aws_secret_access_key": "test-secret-key",
+        },
     ) as client:
         yield client
 
 
 @pytest.fixture
-async def anthropic_client(http_client: httpx.AsyncClient):
+async def http_client_bedrock_legacy():
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app),  # type: ignore
+        base_url="http://test-app.com",
+        headers={
+            "x-upstream-extra-data": json.dumps(
+                {
+                    "claude_client": "legacy",
+                    "aws_access_key_id": "test-access-key",
+                    "aws_secret_access_key": "test-secret-key",
+                }
+            )
+        },
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def http_client_bedrock_mantle():
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app),  # type: ignore
+        base_url="http://test-app.com",
+        headers={
+            "x-upstream-extra-data": json.dumps({"claude_client": "mantle"})
+        },
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def anthropic_client_platform(http_client_platform: httpx.AsyncClient):
     async with anthropic.AsyncAnthropic(
         api_key="test-claude-api-key",
-        http_client=http_client,
+        http_client=http_client_platform,
         max_retries=0,
     ) as client:
         yield client
@@ -77,8 +111,8 @@ class TestMessagesNonStreaming:
         )
 
     @respx.mock
-    async def test_http(self, http_client: httpx.AsyncClient):
-        response = await http_client.post(
+    async def test_http(self, http_client_platform: httpx.AsyncClient):
+        response = await http_client_platform.post(
             "/v1/messages", json=_MESSAGES_REQUEST
         )
 
@@ -91,8 +125,12 @@ class TestMessagesNonStreaming:
         )
 
     @respx.mock
-    async def test_anthropic(self, anthropic_client: anthropic.AsyncAnthropic):
-        response = await anthropic_client.messages.create(**_MESSAGES_REQUEST)
+    async def test_anthropic(
+        self, anthropic_client_platform: anthropic.AsyncAnthropic
+    ):
+        response = await anthropic_client_platform.messages.create(
+            **_MESSAGES_REQUEST
+        )
 
         assert response.type == "message"
         assert response.role == "assistant"
@@ -102,7 +140,7 @@ class TestMessagesNonStreaming:
 
     @respx.mock
     async def test_http_gzip_encoding_stripped(
-        self, mock: respx.MockRouter, http_client: httpx.AsyncClient
+        self, mock: respx.MockRouter, http_client_platform: httpx.AsyncClient
     ):
         content = _read_fixture("messages_non_streaming_response.json")
         mock.post(url="/v1/messages").respond(
@@ -111,7 +149,7 @@ class TestMessagesNonStreaming:
             headers={"Content-Encoding": "gzip"},
         )
 
-        response = await http_client.post(
+        response = await http_client_platform.post(
             "/v1/messages",
             json=_MESSAGES_REQUEST,
             headers={"Accept-Encoding": "gzip"},
@@ -132,9 +170,9 @@ class TestMessagesStreaming:
         )
 
     @respx.mock
-    async def test_http(self, http_client: httpx.AsyncClient):
+    async def test_http(self, http_client_platform: httpx.AsyncClient):
         payload = {**_MESSAGES_REQUEST, "stream": True}
-        response = await http_client.post("/v1/messages", json=payload)
+        response = await http_client_platform.post("/v1/messages", json=payload)
 
         assert response.status_code == 200
         assert "text/event-stream" in response.headers["content-type"]
@@ -143,8 +181,10 @@ class TestMessagesStreaming:
             assert txt.encode() in response.content
 
     @respx.mock
-    async def test_anthropic(self, anthropic_client: anthropic.AsyncAnthropic):
-        async with anthropic_client.messages.stream(
+    async def test_anthropic(
+        self, anthropic_client_platform: anthropic.AsyncAnthropic
+    ):
+        async with anthropic_client_platform.messages.stream(
             **_MESSAGES_REQUEST
         ) as stream:
             text = await stream.get_final_text()
@@ -161,7 +201,7 @@ class TestMessageBatches:
         )
 
     @respx.mock
-    async def test_http(self, http_client: httpx.AsyncClient):
+    async def test_http(self, http_client_platform: httpx.AsyncClient):
         payload = {
             "requests": [
                 {
@@ -170,7 +210,9 @@ class TestMessageBatches:
                 }
             ]
         }
-        response = await http_client.post("/v1/messages/batches", json=payload)
+        response = await http_client_platform.post(
+            "/v1/messages/batches", json=payload
+        )
 
         assert response.status_code == 200
         body = response.json()
@@ -178,8 +220,10 @@ class TestMessageBatches:
         assert body["processing_status"] == "in_progress"
 
     @respx.mock
-    async def test_anthropic(self, anthropic_client: anthropic.AsyncAnthropic):
-        batch = await anthropic_client.messages.batches.create(
+    async def test_anthropic(
+        self, anthropic_client_platform: anthropic.AsyncAnthropic
+    ):
+        batch = await anthropic_client_platform.messages.batches.create(
             requests=[
                 {
                     "custom_id": "req-1",
@@ -201,8 +245,8 @@ class TestCountTokens:
         )
 
     @respx.mock
-    async def test_http(self, http_client: httpx.AsyncClient):
-        response = await http_client.post(
+    async def test_http(self, http_client_platform: httpx.AsyncClient):
+        response = await http_client_platform.post(
             "/v1/messages/count_tokens", json=_BASE_MESSAGES_REQUEST
         )
 
@@ -211,8 +255,10 @@ class TestCountTokens:
         assert body["input_tokens"] == 14
 
     @respx.mock
-    async def test_anthropic(self, anthropic_client: anthropic.AsyncAnthropic):
-        response = await anthropic_client.messages.count_tokens(
+    async def test_anthropic(
+        self, anthropic_client_platform: anthropic.AsyncAnthropic
+    ):
+        response = await anthropic_client_platform.messages.count_tokens(
             **_BASE_MESSAGES_REQUEST
         )
 
@@ -228,7 +274,7 @@ class TestDebugLogging:
     async def test_request_and_response_logging(
         self,
         mock: respx.MockRouter,
-        http_client: httpx.AsyncClient,
+        http_client_platform: httpx.AsyncClient,
         caplog: pytest.LogCaptureFixture,
         level: int,
         expected: bool,
@@ -239,7 +285,7 @@ class TestDebugLogging:
         )
 
         with caplog.at_level(level, logger="bedrock"):
-            response = await http_client.post(
+            response = await http_client_platform.post(
                 "/v1/messages", json=_MESSAGES_REQUEST
             )
 
@@ -263,7 +309,7 @@ class TestDebugLogging:
     async def test_streaming_response_chunk_logging(
         self,
         mock: respx.MockRouter,
-        http_client: httpx.AsyncClient,
+        http_client_platform: httpx.AsyncClient,
         caplog: pytest.LogCaptureFixture,
     ):
         content = _read_fixture("messages_streaming_response.txt")
@@ -273,7 +319,9 @@ class TestDebugLogging:
 
         with caplog.at_level(logging.DEBUG, logger="bedrock"):
             payload = {**_MESSAGES_REQUEST, "stream": True}
-            response = await http_client.post("/v1/messages", json=payload)
+            response = await http_client_platform.post(
+                "/v1/messages", json=payload
+            )
 
         assert response.status_code == 200
 
@@ -296,7 +344,7 @@ class TestDebugLogging:
     async def test_debug_disables_upstream_compression(
         self,
         mock: respx.MockRouter,
-        http_client: httpx.AsyncClient,
+        http_client_platform: httpx.AsyncClient,
         caplog: pytest.LogCaptureFixture,
         level: int,
         expected_encoding: str | None,
@@ -318,7 +366,7 @@ class TestDebugLogging:
         mock.post(url="/v1/messages").mock(side_effect=_handler)
 
         with caplog.at_level(level, logger="bedrock"):
-            response = await http_client.post(
+            response = await http_client_platform.post(
                 "/v1/messages", json=_MESSAGES_REQUEST
             )
 
@@ -339,9 +387,9 @@ class TestRequestHeaderPassthrough:
 
     @respx.mock
     async def test_anthropic_and_encoding_headers_forwarded(
-        self, mock: respx.MockRouter, http_client: httpx.AsyncClient
+        self, mock: respx.MockRouter, http_client_platform: httpx.AsyncClient
     ):
-        response = await http_client.post(
+        response = await http_client_platform.post(
             "/v1/messages",
             json=_MESSAGES_REQUEST,
             headers={
@@ -397,32 +445,23 @@ class TestBuildRequestHeaders:
 
 
 class TestBedrockAnthropicBetaAdaptation:
-    async def test_bedrock_request_adapts_beta_header(self, monkeypatch):
-        captured: dict[str, dict[str, str]] = {}
+    async def test_bedrock_request_adapts_beta_header(
+        self, http_client_bedrock_legacy: httpx.AsyncClient
+    ):
+        # Uses a real AsyncAnthropicBedrock client (rather than patching
+        # create_anthropic_client with a stand-in) so that the adapter's
+        # `isinstance(client, AsyncAnthropicBedrock)` check actually holds
+        # and the beta-header filtering logic is exercised.
+        content = _read_fixture("messages_non_streaming_response.json")
 
-        class _CapturingClient:
-            async def request(self, *, options, **_kwargs):
-                captured["headers"] = options.headers
-                content = _read_fixture("messages_non_streaming_response.json")
-                return _FakeStreamingResponse(
-                    chunks=[content],
-                    headers={"Content-Type": "application/json"},
-                )
+        with respx.mock(
+            base_url="https://bedrock-runtime.test-region.amazonaws.com"
+        ) as mock:
+            route = mock.post(path__regex=r"^/model/.*/invoke$").respond(
+                content=content, content_type="application/json"
+            )
 
-        async def _create_client(_upstream):
-            return _CapturingClient()
-
-        monkeypatch.setattr(
-            "aidial_adapter_bedrock.claude_api.create_anthropic_client",
-            _create_client,
-        )
-
-        async with httpx.AsyncClient(
-            transport=ASGITransport(app),  # type: ignore
-            base_url="http://test-app.com",
-            headers={"x-upstream-extra-data": json.dumps({})},
-        ) as client:
-            response = await client.post(
+            response = await http_client_bedrock_legacy.post(
                 "/v1/messages",
                 json=_MESSAGES_REQUEST,
                 headers={
@@ -435,9 +474,10 @@ class TestBedrockAnthropicBetaAdaptation:
             )
 
         assert response.status_code == 200
+        upstream_headers = route.calls.last.request.headers
         # Bedrock-unsupported flags are stripped; the unknown flag survives.
         assert (
-            captured["headers"]["anthropic-beta"]
+            upstream_headers["anthropic-beta"]
             == "token-efficient-tools-2025-02-19"
         )
 
@@ -451,8 +491,8 @@ class TestModels:
         )
 
     @respx.mock
-    async def test_http(self, http_client: httpx.AsyncClient):
-        response = await http_client.get("/v1/models")
+    async def test_http(self, http_client_platform: httpx.AsyncClient):
+        response = await http_client_platform.get("/v1/models")
 
         assert response.status_code == 200
         body = response.json()
@@ -461,8 +501,10 @@ class TestModels:
         assert body["data"][0]["id"] == "claude-3-5-sonnet-20241022"
 
     @respx.mock
-    async def test_anthropic(self, anthropic_client: anthropic.AsyncAnthropic):
-        models = await anthropic_client.models.list()
+    async def test_anthropic(
+        self, anthropic_client_platform: anthropic.AsyncAnthropic
+    ):
+        models = await anthropic_client_platform.models.list()
 
         assert len(models.data) == 2
         assert models.data[0].id == "claude-3-5-sonnet-20241022"

--- a/tests/unit_tests/test_claude_api.py
+++ b/tests/unit_tests/test_claude_api.py
@@ -43,8 +43,16 @@ _MESSAGES_REQUEST: _MessagesRequest = {
 
 
 @pytest.fixture
-def mock():
+def mock_platform():
     with respx.mock(base_url="https://api.anthropic.com") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_bedrock():
+    with respx.mock(
+        base_url="https://bedrock-runtime.test-region.amazonaws.com"
+    ) as mock:
         yield mock
 
 
@@ -104,9 +112,9 @@ async def anthropic_client_platform(http_client_platform: httpx.AsyncClient):
 
 class TestMessagesNonStreaming:
     @pytest.fixture(autouse=True)
-    def _setup(self, mock: respx.MockRouter):
+    def _setup(self, mock_platform: respx.MockRouter):
         content = _read_fixture("messages_non_streaming_response.json")
-        mock.post(url="/v1/messages").respond(
+        mock_platform.post(url="/v1/messages").respond(
             content=content, content_type="application/json"
         )
 
@@ -140,10 +148,12 @@ class TestMessagesNonStreaming:
 
     @respx.mock
     async def test_http_gzip_encoding_stripped(
-        self, mock: respx.MockRouter, http_client_platform: httpx.AsyncClient
+        self,
+        mock_platform: respx.MockRouter,
+        http_client_platform: httpx.AsyncClient,
     ):
         content = _read_fixture("messages_non_streaming_response.json")
-        mock.post(url="/v1/messages").respond(
+        mock_platform.post(url="/v1/messages").respond(
             content=gzip.compress(content),
             content_type="application/json",
             headers={"Content-Encoding": "gzip"},
@@ -163,9 +173,9 @@ class TestMessagesNonStreaming:
 
 class TestMessagesStreaming:
     @pytest.fixture(autouse=True)
-    def _setup(self, mock: respx.MockRouter):
+    def _setup(self, mock_platform: respx.MockRouter):
         content = _read_fixture("messages_streaming_response.txt")
-        mock.post("/v1/messages").respond(
+        mock_platform.post("/v1/messages").respond(
             content=content, content_type="text/event-stream"
         )
 
@@ -194,9 +204,9 @@ class TestMessagesStreaming:
 
 class TestMessageBatches:
     @pytest.fixture(autouse=True)
-    def _setup(self, mock: respx.MockRouter):
+    def _setup(self, mock_platform: respx.MockRouter):
         content = _read_fixture("batches_response.json")
-        mock.post(url="/v1/messages/batches").respond(
+        mock_platform.post(url="/v1/messages/batches").respond(
             content=content, content_type="application/json"
         )
 
@@ -238,9 +248,9 @@ class TestMessageBatches:
 
 class TestCountTokens:
     @pytest.fixture(autouse=True)
-    def _setup(self, mock: respx.MockRouter):
+    def _setup(self, mock_platform: respx.MockRouter):
         content = _read_fixture("count_tokens_response.json")
-        mock.post(url="/v1/messages/count_tokens").respond(
+        mock_platform.post(url="/v1/messages/count_tokens").respond(
             content=content, content_type="application/json"
         )
 
@@ -273,14 +283,14 @@ class TestDebugLogging:
     @respx.mock
     async def test_request_and_response_logging(
         self,
-        mock: respx.MockRouter,
+        mock_platform: respx.MockRouter,
         http_client_platform: httpx.AsyncClient,
         caplog: pytest.LogCaptureFixture,
         level: int,
         expected: bool,
     ):
         content = _read_fixture("messages_non_streaming_response.json")
-        mock.post(url="/v1/messages").respond(
+        mock_platform.post(url="/v1/messages").respond(
             content=content, content_type="application/json"
         )
 
@@ -308,12 +318,12 @@ class TestDebugLogging:
     @respx.mock
     async def test_streaming_response_chunk_logging(
         self,
-        mock: respx.MockRouter,
+        mock_platform: respx.MockRouter,
         http_client_platform: httpx.AsyncClient,
         caplog: pytest.LogCaptureFixture,
     ):
         content = _read_fixture("messages_streaming_response.txt")
-        mock.post("/v1/messages").respond(
+        mock_platform.post("/v1/messages").respond(
             content=content, content_type="text/event-stream"
         )
 
@@ -343,7 +353,7 @@ class TestDebugLogging:
     @respx.mock
     async def test_debug_disables_upstream_compression(
         self,
-        mock: respx.MockRouter,
+        mock_platform: respx.MockRouter,
         http_client_platform: httpx.AsyncClient,
         caplog: pytest.LogCaptureFixture,
         level: int,
@@ -363,7 +373,7 @@ class TestDebugLogging:
                 headers={"content-type": "application/json"},
             )
 
-        mock.post(url="/v1/messages").mock(side_effect=_handler)
+        mock_platform.post(url="/v1/messages").mock(side_effect=_handler)
 
         with caplog.at_level(level, logger="bedrock"):
             response = await http_client_platform.post(
@@ -379,15 +389,17 @@ class TestDebugLogging:
 
 class TestRequestHeaderPassthrough:
     @pytest.fixture(autouse=True)
-    def _setup(self, mock: respx.MockRouter):
+    def _setup(self, mock_platform: respx.MockRouter):
         content = _read_fixture("messages_non_streaming_response.json")
-        mock.post(url="/v1/messages").respond(
+        mock_platform.post(url="/v1/messages").respond(
             content=content, content_type="application/json"
         )
 
     @respx.mock
     async def test_anthropic_and_encoding_headers_forwarded(
-        self, mock: respx.MockRouter, http_client_platform: httpx.AsyncClient
+        self,
+        mock_platform: respx.MockRouter,
+        http_client_platform: httpx.AsyncClient,
     ):
         response = await http_client_platform.post(
             "/v1/messages",
@@ -401,7 +413,7 @@ class TestRequestHeaderPassthrough:
 
         assert response.status_code == 200
 
-        upstream_headers = mock.calls.last.request.headers
+        upstream_headers = mock_platform.calls.last.request.headers
         # Anthropic-specific headers must reach the upstream.
         assert (
             upstream_headers["anthropic-beta"]
@@ -445,8 +457,11 @@ class TestBuildRequestHeaders:
 
 
 class TestBedrockAnthropicBetaAdaptation:
-    async def test_bedrock_request_adapts_beta_header(
-        self, http_client_bedrock_legacy: httpx.AsyncClient
+    @respx.mock
+    async def test_bedrock_legacy_request_adapts_beta_header(
+        self,
+        mock_bedrock: respx.MockRouter,
+        http_client_bedrock_legacy: httpx.AsyncClient,
     ):
         # Uses a real AsyncAnthropicBedrock client (rather than patching
         # create_anthropic_client with a stand-in) so that the adapter's
@@ -454,24 +469,21 @@ class TestBedrockAnthropicBetaAdaptation:
         # and the beta-header filtering logic is exercised.
         content = _read_fixture("messages_non_streaming_response.json")
 
-        with respx.mock(
-            base_url="https://bedrock-runtime.test-region.amazonaws.com"
-        ) as mock:
-            route = mock.post(path__regex=r"^/model/.*/invoke$").respond(
-                content=content, content_type="application/json"
-            )
+        route = mock_bedrock.post(path__regex=r"^/model/.*/invoke$").respond(
+            content=content, content_type="application/json"
+        )
 
-            response = await http_client_bedrock_legacy.post(
-                "/v1/messages",
-                json=_MESSAGES_REQUEST,
-                headers={
-                    "anthropic-beta": (
-                        "oauth-2025-04-20,"
-                        "token-efficient-tools-2025-02-19,"
-                        "thinking-token-count-2026-05-13"
-                    )
-                },
-            )
+        response = await http_client_bedrock_legacy.post(
+            "/v1/messages",
+            json=_MESSAGES_REQUEST,
+            headers={
+                "anthropic-beta": (
+                    "oauth-2025-04-20,"
+                    "token-efficient-tools-2025-02-19,"
+                    "thinking-token-count-2026-05-13"
+                )
+            },
+        )
 
         assert response.status_code == 200
         upstream_headers = route.calls.last.request.headers
@@ -484,9 +496,9 @@ class TestBedrockAnthropicBetaAdaptation:
 
 class TestModels:
     @pytest.fixture(autouse=True)
-    def _setup(self, mock: respx.MockRouter):
+    def _setup(self, mock_platform: respx.MockRouter):
         content = _read_fixture("models_response.json")
-        mock.get(url="/v1/models").respond(
+        mock_platform.get(url="/v1/models").respond(
             content=content, content_type="application/json"
         )
 


### PR DESCRIPTION
- for api.anthropic - pass-through
- for bedrock models - drop unsupported by bedrock beta values

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
