### PR TITLE
fix: patch release 0.43.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ Copy `.env.example` to `.env` and customize it for your environment:
 |CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request.<br>**:warning: Using the variable is discouraged**.<br>Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
 |BOTOCORE_MAX_RETRY_ATTEMPTS|0|How many times to retry chat model requests made via the Bedrock API or Converse API when the provider returns a retriable error|
 |ANTHROPIC_MAX_RETRY_ATTEMPTS|0|How many times to retry Anthropic chat model requests when the provider returns a retriable error|
+|REQUEST_TIMEOUT_SECONDS|600|The request timeout in seconds (read, write and pool) for the requests to AWS Bedrock.|
 
 ### Session Tags
 

--- a/aidial_adapter_bedrock/bedrock.py
+++ b/aidial_adapter_bedrock/bedrock.py
@@ -7,7 +7,6 @@ from functools import cache as functools_cache
 from logging import DEBUG
 from typing import Any, TypedDict, Unpack, assert_never
 
-import anthropic
 import boto3
 import botocore
 import httpx
@@ -49,6 +48,9 @@ BOTOCORE_CLIENT_MAX_POOL_CONNECTIONS = get_env_int(
 )
 ANTHROPIC_MAX_RETRY_ATTEMPTS = get_env_int("ANTHROPIC_MAX_RETRY_ATTEMPTS", 0)
 
+# Same as Anthropic SDK timeouts: anthropic._constants.DEFAULT_TIMEOUT
+DEFAULT_TIMEOUTS = httpx.Timeout(timeout=10 * 60, connect=5.0)
+
 
 class _BedrockClientParams(TypedDict):
     aws_region: str
@@ -74,7 +76,7 @@ def get_default_anthropic_timeout() -> httpx.Timeout:
     # stream=False & max_tokens>=128K/6:
     # https://github.com/anthropics/anthropic-sdk-python/blob/f5bdf5137cc3da4d3663aedb8c63d54652981c3b/src/anthropic/resources/beta/messages/messages.py#L2175-L2176
 
-    timeout = anthropic._constants.DEFAULT_TIMEOUT.as_dict()
+    timeout = DEFAULT_TIMEOUTS.as_dict()
     timeout["connect"] *= 1.0001  # type: ignore
     return httpx.Timeout(**timeout)
 
@@ -144,6 +146,9 @@ async def create_boto_client(
         # The max number of connections to the same upstream that are persisted (saved to a connection pool).
         # Greater number of connections *don't block* each other.
         max_pool_connections=BOTOCORE_CLIENT_MAX_POOL_CONNECTIONS,
+        # Overriding Botocore default read timeout of 60s,
+        # which is too short for non-streaming Converse API requests.
+        read_timeout=DEFAULT_TIMEOUTS.read,
         retries={
             "mode": "standard",
             "total_max_attempts": 1 + _get_botocore_max_retry_attempts(),

--- a/aidial_adapter_bedrock/bedrock.py
+++ b/aidial_adapter_bedrock/bedrock.py
@@ -49,7 +49,9 @@ BOTOCORE_CLIENT_MAX_POOL_CONNECTIONS = get_env_int(
 ANTHROPIC_MAX_RETRY_ATTEMPTS = get_env_int("ANTHROPIC_MAX_RETRY_ATTEMPTS", 0)
 
 # Same as Anthropic SDK timeouts: anthropic._constants.DEFAULT_TIMEOUT
-DEFAULT_TIMEOUTS = httpx.Timeout(timeout=10 * 60, connect=5.0)
+DEFAULT_TIMEOUTS = httpx.Timeout(
+    timeout=get_env_int("REQUEST_TIMEOUT_SECONDS", 10 * 60), connect=5.0
+)
 
 
 class _BedrockClientParams(TypedDict):


### PR DESCRIPTION
- **fix: increase read timeout for the Bedrock client to 600s (#487)**
- **feat: make the Bedrock request timeout configurable via REQUEST_TIMEOUT_SECONDS (#489)**
