### PR TITLE
chore: fix security issues with `libuuid` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN pip install setuptools==80.10.2
 RUN pip install wheel==0.46.2
 # fix CVE-2025-6965 and CVE-2026-22184 and CVE-2026-40200
 RUN apk upgrade --no-cache sqlite-libs zlib musl musl-utils
+# fix CVE-2026-53612, CVE-2026-53613, CVE-2026-53614, CVE-2026-76642, CVE-2026-78408, CVE-2026-78409, CVE-2026-78410
+RUN apk upgrade --no-cache libuuid
 
 WORKDIR /app
 


### PR DESCRIPTION
fix CVE-2026-53612, CVE-2026-53613, CVE-2026-53614, CVE-2026-76642, CVE-2026-78408, CVE-2026-78409, CVE-2026-78410